### PR TITLE
Standardize k-binning for volume-independent summary statistics

### DIFF
--- a/cmass/diagnostics/calculations.py
+++ b/cmass/diagnostics/calculations.py
@@ -10,6 +10,12 @@ import BFast
 import PolyBin3D as pb
 from ..utils import timing_decorator
 
+# Fixed k-binning for all summary statistics
+K_MIN = 0.01    # h/Mpc, first bin edge
+DK_PK = 0.01   # h/Mpc, bin width for P(k)
+DK_BK = 0.02   # h/Mpc, bin width for B(k)
+K_MAX_BK = 0.40  # h/Mpc, hard kmax for B(k)
+
 
 def MA(pos, L, N, MAS='CIC'):
     pos = np.ascontiguousarray(pos)
@@ -34,8 +40,28 @@ def MAz(pos, vel, L, N, cosmo, z, MAS='CIC', axis=0):
 def calcPk(delta, L, axis=0, MAS='CIC', threads=16):
     Pk = PKL.Pk(delta.astype(np.float32), L, axis, MAS, threads, verbose=False)
     k = Pk.k3D
+    Nmodes = Pk.Nmodes3D
     Pk = Pk.Pk
-    return k, Pk
+    return k, Pk, Nmodes
+
+
+def rebin_pk(k, Pk, Nmodes):
+    """Rebin pylians P(k) onto a fixed grid using mode-weighted averaging.
+
+    Pk has shape (N_bins_fine, n_ell). Returns (k_centers, Pk_rebinned).
+    """
+    k_nyq = k.max()
+    k_edges = np.arange(K_MIN, k_nyq + DK_PK, DK_PK)
+    k_centers = 0.5 * (k_edges[:-1] + k_edges[1:])
+    n_ell = Pk.shape[1] if Pk.ndim > 1 else 1
+    Pk_out = np.full((len(k_centers), n_ell), np.nan)
+    for i, (lo, hi) in enumerate(zip(k_edges[:-1], k_edges[1:])):
+        mask = (k >= lo) & (k < hi)
+        if not mask.any():
+            continue
+        w = Nmodes[mask]
+        Pk_out[i] = np.average(Pk[mask], weights=w, axis=0)
+    return k_centers, Pk_out
 
 
 def calcQk_polybin(k, Pk, k123, Bk):
@@ -52,11 +78,8 @@ def calcQk_polybin(k, Pk, k123, Bk):
 def calcBk_polybin(delta, L, axis=0, MAS='CIC', threads=16):
     assert axis == 2  # polybin measures along the z axis
 
-    # TODO: Use ili-summarizer here
-    k_min = 2 * np.pi / L
     n_mesh = delta.shape[0]
-    k_max = np.pi * n_mesh / L
-    k_bins = np.arange(k_min, k_max, k_min * 5)
+    k_bins = np.arange(K_MIN, K_MAX_BK + DK_BK, DK_BK)
 
     # set stuff up
     base = pb.PolyBin3D(

--- a/cmass/diagnostics/calculations.py
+++ b/cmass/diagnostics/calculations.py
@@ -132,12 +132,14 @@ def calcBk_bfast(delta, L, axis=0, MAS='CIC', threads=16, cache_dir=None):
     counts = result[mask, 7]  # number of triangles in each bin (not used)
     qk = calcQk_bfast(pk, bk)
 
-    return k123, bk, qk, k123, pk
+    # 1D k-bin centers for the power spectrum, extracted from the triangle legs
+    k1d = np.unique(k123)
+    return k123, bk, qk, k1d, pk
 
 
-def get_redshift_space_pos(pos, vel, L, h, z, axis=0):
+def get_redshift_space_pos(pos, vel, L, cosmo, z, axis=0):
     pos, vel = map(np.ascontiguousarray, (pos, vel))
-    RSL.pos_redshift_space(pos, vel, L, h*100, z, axis)
+    RSL.pos_redshift_space(pos, vel, L, cosmo.H(z).value/cosmo.h, z, axis)
     pos %= L
     return pos
 
@@ -153,6 +155,6 @@ def get_box_catalogue(pos, z, L, N):
     )
 
 
-def get_box_catalogue_rsd(pos, vel, z, L, h, axis, N):
-    pos = get_redshift_space_pos(pos=pos, vel=vel, z=z, h=h, axis=axis, L=L,)
+def get_box_catalogue_rsd(pos, vel, z, L, cosmo, axis, N):
+    pos = get_redshift_space_pos(pos=pos, vel=vel, z=z, cosmo=cosmo, axis=axis, L=L)
     return get_box_catalogue(pos, z, L, N)

--- a/cmass/diagnostics/calculations.py
+++ b/cmass/diagnostics/calculations.py
@@ -17,6 +17,7 @@ DK_BK = 0.02   # h/Mpc, bin width for B(k)
 K_MAX_BK = 0.40  # h/Mpc, hard kmax for B(k)
 
 
+
 def MA(pos, L, N, MAS='CIC'):
     pos = np.ascontiguousarray(pos)
     pos = copy.deepcopy(pos)
@@ -60,11 +61,9 @@ def rebin_pk(k, Pk, Nmodes):
     k-modes that fall in the coarse bin.
 
     Pk has shape (N_bins_fine, n_ell) where n_ell=3 (monopole, quadrupole,
-    hexadecapole) as returned by pylians. Returns (k_centers, Pk_rebinned,
-    Nmodes_rebinned) where Pk_rebinned has shape (N_bins_coarse, n_ell) and
-    Nmodes_rebinned has shape (N_bins_coarse,) — the total mode count per
-    coarse bin, saved so downstream rebinning can remain mode-weighted.
-    Output bins that contain no pylians modes are left as nan / 0.
+    hexadecapole) as returned by pylians. Returns (k_centers, Pk_rebinned)
+    where Pk_rebinned has shape (N_bins_coarse, n_ell). Output bins that
+    contain no pylians modes are left as nan.
     """
     k_nyq = k.max()
     # Build fixed output bin edges and centers
@@ -72,7 +71,6 @@ def rebin_pk(k, Pk, Nmodes):
     k_centers = 0.5 * (k_edges[:-1] + k_edges[1:])
     n_ell = Pk.shape[1] if Pk.ndim > 1 else 1
     Pk_out = np.full((len(k_centers), n_ell), np.nan)
-    Nmodes_out = np.zeros(len(k_centers), dtype=np.float64)
     for i, (lo, hi) in enumerate(zip(k_edges[:-1], k_edges[1:])):
         # Select all pylians bins whose centers fall in this output bin
         mask = (k >= lo) & (k < hi)
@@ -81,9 +79,7 @@ def rebin_pk(k, Pk, Nmodes):
         # Weight by number of Fourier modes: more modes = lower variance = higher weight
         w = Nmodes[mask]
         Pk_out[i] = np.average(Pk[mask], weights=w, axis=0)
-        # Total mode count for this coarse bin, used for further downstream rebinning
-        Nmodes_out[i] = w.sum()
-    return k_centers, Pk_out, Nmodes_out
+    return k_centers, Pk_out
 
 
 def calcQk_polybin(k, Pk, k123, Bk):

--- a/cmass/diagnostics/calculations.py
+++ b/cmass/diagnostics/calculations.py
@@ -46,22 +46,44 @@ def calcPk(delta, L, axis=0, MAS='CIC', threads=16):
 
 
 def rebin_pk(k, Pk, Nmodes):
-    """Rebin pylians P(k) onto a fixed grid using mode-weighted averaging.
+    """Rebin pylians P(k) onto a fixed physical grid using mode-weighted averaging.
 
-    Pk has shape (N_bins_fine, n_ell). Returns (k_centers, Pk_rebinned).
+    Pylians bins at width k_F = 2pi/L, which varies with box size. This maps
+    those fine, volume-dependent bins onto a fixed grid (K_MIN, k_Nyq, DK_PK)
+    so that the output data vector has consistent meaning and length across
+    simulations of different volumes.
+
+    Within each output bin, modes are averaged weighted by Nmodes — the number
+    of Fourier modes in each fine bin. This is the statistically correct weight:
+    bins with more modes have smaller variance and should contribute more to the
+    average. It is equivalent to computing the straight average of all individual
+    k-modes that fall in the coarse bin.
+
+    Pk has shape (N_bins_fine, n_ell) where n_ell=3 (monopole, quadrupole,
+    hexadecapole) as returned by pylians. Returns (k_centers, Pk_rebinned,
+    Nmodes_rebinned) where Pk_rebinned has shape (N_bins_coarse, n_ell) and
+    Nmodes_rebinned has shape (N_bins_coarse,) — the total mode count per
+    coarse bin, saved so downstream rebinning can remain mode-weighted.
+    Output bins that contain no pylians modes are left as nan / 0.
     """
     k_nyq = k.max()
+    # Build fixed output bin edges and centers
     k_edges = np.arange(K_MIN, k_nyq + DK_PK, DK_PK)
     k_centers = 0.5 * (k_edges[:-1] + k_edges[1:])
     n_ell = Pk.shape[1] if Pk.ndim > 1 else 1
     Pk_out = np.full((len(k_centers), n_ell), np.nan)
+    Nmodes_out = np.zeros(len(k_centers), dtype=np.float64)
     for i, (lo, hi) in enumerate(zip(k_edges[:-1], k_edges[1:])):
+        # Select all pylians bins whose centers fall in this output bin
         mask = (k >= lo) & (k < hi)
         if not mask.any():
             continue
+        # Weight by number of Fourier modes: more modes = lower variance = higher weight
         w = Nmodes[mask]
         Pk_out[i] = np.average(Pk[mask], weights=w, axis=0)
-    return k_centers, Pk_out
+        # Total mode count for this coarse bin, used for further downstream rebinning
+        Nmodes_out[i] = w.sum()
+    return k_centers, Pk_out, Nmodes_out
 
 
 def calcQk_polybin(k, Pk, k123, Bk):
@@ -117,6 +139,7 @@ def calcBk_polybin(delta, L, axis=0, MAS='CIC', threads=16):
     pk = np.array([pk_corr[f'p{ell}'] for ell in [0, 2]])
     bk = np.array([bk_corr[f'b{ell}'] for ell in [0, 2]])
     qk = calcQk_polybin(k, pk, k123, bk)
+
     return k123, bk, qk, k, pk
 
 

--- a/cmass/diagnostics/calculations.py
+++ b/cmass/diagnostics/calculations.py
@@ -10,10 +10,21 @@ import BFast
 import PolyBin3D as pb
 from ..utils import timing_decorator
 
-# Fixed k-binning for all summary statistics
+# Fixed k-binning for all summary statistics.
+# These are shared across all volumes so the data vector has consistent length
+# and meaning for SBI, regardless of box size.
+#
+# K_MIN: set to ~k_F of the largest volume we use (3 Gpc/h → k_F ≈ 0.002),
+#   rounded up to 0.01 to exclude the noisiest large-scale modes.
+# DK_PK: dk=0.01 gives ~40 Pk bins (k_Nyq ≈ 0.40 is volume-independent),
+#   comfortably O(100).
+# DK_BK: dk=0.04 gives ~220 Bk triangles — chosen to keep the Bk data vector
+#   O(100-200). Finer bins (dk=0.02) give 1540 triangles, which is too large.
+# K_MAX_BK: 0.40 h/Mpc matches k_Nyquist for our standard mesh (N=128 per Gpc/h),
+#   so we use all available signal without extrapolating.
 K_MIN = 0.01    # h/Mpc, first bin edge
-DK_PK = 0.01   # h/Mpc, bin width for P(k)
-DK_BK = 0.02   # h/Mpc, bin width for B(k)
+DK_PK = 0.01   # h/Mpc, bin width for P(k)  → ~40 bins
+DK_BK = 0.04   # h/Mpc, bin width for B(k)  → ~220 triangles
 K_MAX_BK = 0.40  # h/Mpc, hard kmax for B(k)
 
 

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -38,11 +38,10 @@ def run_pylians(
     pfx = 'z' if use_rsd else ''
     k, Pk, Nmodes = calcPk(field, box_size, axis=axis,
                            MAS=MAS, threads=num_threads)
-    k, Pk, Nmodes = rebin_pk(k, Pk, Nmodes)
+    k, Pk = rebin_pk(k, Pk, Nmodes)
     out = {
         pfx+'Pk_k3D': k,
         pfx+'Pk': Pk,
-        pfx+'Pk_Nmodes': Nmodes,
     }
     return out
 

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -24,7 +24,7 @@ from .tools import (
     _get_snapshot_alist, save_group
 )
 from .calculations import (
-    MA, MAz, calcPk, calcBk_bfast, calcBk_polybin,
+    MA, MAz, calcPk, rebin_pk, calcBk_bfast, calcBk_polybin,
     get_box_catalogue, get_box_catalogue_rsd  # not used
 )
 from .geometry import SURVEY_GEOMETRIES
@@ -36,8 +36,9 @@ def run_pylians(
 ):
     # Only for power spectrum
     pfx = 'z' if use_rsd else ''
-    k, Pk = calcPk(field, box_size, axis=axis,
-                   MAS=MAS, threads=num_threads)
+    k, Pk, Nmodes = calcPk(field, box_size, axis=axis,
+                           MAS=MAS, threads=num_threads)
+    k, Pk = rebin_pk(k, Pk, Nmodes)
     out = {
         pfx+'Pk_k3D': k,
         pfx+'Pk': Pk

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -38,10 +38,11 @@ def run_pylians(
     pfx = 'z' if use_rsd else ''
     k, Pk, Nmodes = calcPk(field, box_size, axis=axis,
                            MAS=MAS, threads=num_threads)
-    k, Pk = rebin_pk(k, Pk, Nmodes)
+    k, Pk, Nmodes = rebin_pk(k, Pk, Nmodes)
     out = {
         pfx+'Pk_k3D': k,
-        pfx+'Pk': Pk
+        pfx+'Pk': Pk,
+        pfx+'Pk_Nmodes': Nmodes,
     }
     return out
 

--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -147,7 +147,7 @@ def summarize_rho(
                 backend=config.diag.bispectrum_backend
             )
             out_data.update(out)
-        if len(out) > 0:
+        if len(out_data) > 0:
             save_group(outpath, out_data, None, a, config)
     return True
 

--- a/cmass/infer/loaders.py
+++ b/cmass/infer/loaders.py
@@ -274,7 +274,7 @@ def _filter_Bk(X, kmin, kmax, equilateral=False, squeezed=False,
 
 
 def preprocess_Bk(data, kmin, kmax, norm=None,
-                  mode=None,  # None, Eq, Sq, SS, or Is
+                  mode=None,  # None, Eq, Sq, Ss, or Is
                   correct_shot=False):
     # process Bk: filtering for k's, normalizing, and flattening
     filter_kwargs = dict(

--- a/cmass/infer/loaders.py
+++ b/cmass/infer/loaders.py
@@ -56,8 +56,6 @@ def load_Pk(diag_file, a):
             # load the summaries
             for stat in ['Pk', 'zPk']:
                 if stat in f[a]:
-                    nmodes_key = stat + '_Nmodes'
-                    nmodes = f[a][nmodes_key][:] if nmodes_key in f[a] else None
                     for i in range(3):  # monopole, quadrupole, hexadecapole
                         summ[stat+str(2*i)] = {
                             'k': f[a][stat+'_k3D'][:],
@@ -65,7 +63,6 @@ def load_Pk(diag_file, a):
                             'nbar': f[a].attrs['nbar'],
                             'log10nbar': f[a].attrs['log10nbar'],
                             'a_loaded': a,
-                            'Nmodes': nmodes,
                         }
     except (OSError, KeyError):
         return {}
@@ -80,7 +77,6 @@ def load_lc_Pk(diag_file):
         with h5py.File(diag_file, 'r') as f:
             # load the summaries
             stat = 'Pk'
-            nmodes = f['Pk_Nmodes'][:] if 'Pk_Nmodes' in f else None
             for i in range(3):  # monopole, quadrupole, hexadecapole
                 summ[stat+str(2*i)] = {
                     'k': f[stat+'_k3D'][:],
@@ -89,7 +85,6 @@ def load_lc_Pk(diag_file):
                     'log10nbar': f.attrs['log10nbar'],
                     'nz': f['nz'][:],
                     'nz_bins': f['nz_bins'][:],
-                    'Nmodes': nmodes,
                 }
     except (OSError, KeyError):
         return {}
@@ -155,16 +150,6 @@ def _filter_Pk(X, kmin, kmax):
         [x['value'][_is_in_kminmax(x['k'], kmin, kmax)] for x in X])
 
 
-def _get_Nmodes_Pk(data, kmin, kmax):
-    # Extract Nmodes for the k-bins that survive the kmin/kmax cut.
-    # Nmodes is the same for all sims (fixed grid), so we only need one entry.
-    nmodes = data[0].get('Nmodes', None)
-    if nmodes is None:
-        return None
-    k = data[0]['k']
-    return nmodes[_is_in_kminmax(k, kmin, kmax)]
-
-
 def _get_nbar(data):
     return np.array([x['nbar'] for x in data]).reshape(-1, 1)
 
@@ -200,50 +185,13 @@ def _get_log10nz(data):
     return binned_nz_logged  # shape: (num_entries, num_bins*num_repeat)
 
 
-def rebin_Pk_to_length(X, max_length, Nmodes=None):
-    """Coarsen Pk from shape (N_sims, N) to at most (N_sims, max_length).
-
-    Groups consecutive k-bins and averages within each group, weighted by
-    Nmodes (total Fourier mode count per bin). Falls back to uniform averaging
-    if Nmodes is None (e.g. old files without Pk_Nmodes saved).
-    """
-    N = X.shape[1]
-    if N <= max_length:
-        return X
-    group_size = int(np.ceil(N / max_length))
-    N_trimmed = (N // group_size) * group_size
-    X_t = X[:, :N_trimmed].reshape(X.shape[0], -1, group_size)  # (N_sims, n_out, group)
-    if Nmodes is not None:
-        w = Nmodes[:N_trimmed].reshape(-1, group_size)           # (n_out, group)
-        return np.einsum('sog,og->so', X_t, w) / w.sum(axis=1)
-    return X_t.mean(axis=2)
-
-
-def rebin_Bk_to_length(X, max_length):
-    """Coarsen Bk from shape (N_sims, N_triangles) to at most (N_sims, max_length).
-
-    Groups consecutive triangles and averages uniformly within each group.
-    NOTE: this is approximate — the exact weight per triangle is the number of
-    fundamental-mode triplets in the bin, which is not currently saved. Uniform
-    averaging is a reasonable substitute since B(k) is smooth, but it is not
-    the minimum-variance estimate. Order also matters: this must be called on
-    raw B(k) before signed_log so that mean(B) is averaged rather than mean(log B).
-    """
-    N = X.shape[1]
-    if N <= max_length:
-        return X
-    group_size = int(np.ceil(N / max_length))
-    N_trimmed = (N // group_size) * group_size
-    return X[:, :N_trimmed].reshape(X.shape[0], -1, group_size).mean(axis=2)
-
-
 def signed_log(x, base=10):
     # Compute the signed logarithm of x (for negative values)
     return np.sign(x) * np.log1p(np.abs(x)) / np.log(base)
 
 
 def preprocess_Pk(data, kmin, kmax, norm=None, correct_shot=False,
-                  loglinear_start_idx=None, max_length=None):
+                  loglinear_start_idx=None):
     # process Pk: filtering for k's, normalizing, and flattening
 
     X = _filter_Pk(data, kmin, kmax)
@@ -251,18 +199,9 @@ def preprocess_Pk(data, kmin, kmax, norm=None, correct_shot=False,
     if norm is None:  # monopole case
         if correct_shot:
             X -= 1./_get_nbar(data)  # subtract shot noise
-        # Rebin on raw P(k) before log so mode-weighted averaging is exact:
-        # mean(log P) != log(mean(P)), so order matters here.
-        if max_length is not None:
-            Nmodes = _get_Nmodes_Pk(data, kmin, kmax)
-            X = rebin_Pk_to_length(X, max_length, Nmodes)
         X = signed_log(X)
     else:  # higher multipoles normalized by monopole
         Xnorm = _filter_Pk(norm, kmin, kmax)
-        if max_length is not None:
-            Nmodes = _get_Nmodes_Pk(data, kmin, kmax)
-            X = rebin_Pk_to_length(X, max_length, Nmodes)
-            Xnorm = rebin_Pk_to_length(Xnorm, max_length, Nmodes)
         X /= Xnorm
 
     if loglinear_start_idx is not None:
@@ -300,6 +239,22 @@ def _is_subsampled(k):
     return np.arange(len(k[0])) % 5 == 0
 
 
+def _get_Bk_mask(k123, kmin, kmax, equilateral=False, squeezed=False,
+                 subsampled=False, isoceles=False):
+    mask = _is_in_kminmax(k123, kmin, kmax)
+    if equilateral:
+        mask &= _is_equilateral(k123)
+    elif squeezed:
+        mask &= _is_squeezed(k123)
+    elif subsampled:
+        mask &= _is_subsampled(k123)
+    elif isoceles:
+        mask &= _is_isoceles(k123)
+    else:
+        mask &= _is_valid_triangle(k123)
+    return mask
+
+
 def _filter_Bk(X, kmin, kmax, equilateral=False, squeezed=False,
                subsampled=False, isoceles=False):
     if sum([equilateral, squeezed, subsampled]) > 1:
@@ -313,23 +268,14 @@ def _filter_Bk(X, kmin, kmax, equilateral=False, squeezed=False,
         raise ValueError("k values are not consistent across samples.")
 
     k123 = k123[0]
-    mask = _is_in_kminmax(k123, kmin, kmax)
-    if equilateral:
-        mask &= _is_equilateral(k123)
-    elif squeezed:
-        mask &= _is_squeezed(k123)
-    elif subsampled:
-        mask &= _is_subsampled(k123)
-    elif isoceles:
-        mask &= _is_isoceles(k123)
-    else:
-        mask &= _is_valid_triangle(k123)
+    mask = _get_Bk_mask(k123, kmin, kmax, equilateral, squeezed,
+                        subsampled, isoceles)
     return X[:, mask]
 
 
 def preprocess_Bk(data, kmin, kmax, norm=None,
                   mode=None,  # None, Eq, Sq, SS, or Is
-                  correct_shot=False, max_length=None):
+                  correct_shot=False):
     # process Bk: filtering for k's, normalizing, and flattening
     filter_kwargs = dict(
         equilateral=(mode == 'Eq'),
@@ -343,16 +289,9 @@ def preprocess_Bk(data, kmin, kmax, norm=None,
         pass  # not implemented because I'm not sure its right
 
     if norm is None:  # monopole case
-        # Rebin before log: mean(log B) != log(mean(B)), so order matters.
-        # Weighting is uniform (approximate) — see rebin_Bk_to_length docstring.
-        if max_length is not None:
-            X = rebin_Bk_to_length(X, max_length)
         X = signed_log(X)
     else:  # higher multipoles normalized by monopole
         Xnorm = _filter_Bk(norm, kmin, kmax, **filter_kwargs)
-        if max_length is not None:
-            X = rebin_Bk_to_length(X, max_length)
-            Xnorm = rebin_Bk_to_length(Xnorm, max_length)
         X /= Xnorm
 
     return np.nan_to_num(X, nan=0.0).reshape(len(X), -1)

--- a/cmass/infer/loaders.py
+++ b/cmass/infer/loaders.py
@@ -56,13 +56,17 @@ def load_Pk(diag_file, a):
             # load the summaries
             for stat in ['Pk', 'zPk']:
                 if stat in f[a]:
+                    nmodes_key = stat + '_Nmodes'
+                    nmodes = f[a][nmodes_key][:] if nmodes_key in f[a] else None
                     for i in range(3):  # monopole, quadrupole, hexadecapole
                         summ[stat+str(2*i)] = {
                             'k': f[a][stat+'_k3D'][:],
                             'value': f[a][stat][:, i],
                             'nbar': f[a].attrs['nbar'],
                             'log10nbar': f[a].attrs['log10nbar'],
-                            'a_loaded': a}
+                            'a_loaded': a,
+                            'Nmodes': nmodes,
+                        }
     except (OSError, KeyError):
         return {}
     return summ
@@ -76,6 +80,7 @@ def load_lc_Pk(diag_file):
         with h5py.File(diag_file, 'r') as f:
             # load the summaries
             stat = 'Pk'
+            nmodes = f['Pk_Nmodes'][:] if 'Pk_Nmodes' in f else None
             for i in range(3):  # monopole, quadrupole, hexadecapole
                 summ[stat+str(2*i)] = {
                     'k': f[stat+'_k3D'][:],
@@ -84,6 +89,7 @@ def load_lc_Pk(diag_file):
                     'log10nbar': f.attrs['log10nbar'],
                     'nz': f['nz'][:],
                     'nz_bins': f['nz_bins'][:],
+                    'Nmodes': nmodes,
                 }
     except (OSError, KeyError):
         return {}
@@ -98,18 +104,19 @@ def load_Bk(diag_file, a):
         with h5py.File(diag_file, 'r') as f:
             a = closest_a(f.keys(), a)
             a = f'{a:.6f}'
-            # load the summaries
+            g = f[a]
             for stat in ['Bk', 'Qk', 'zBk', 'zQk']:
-                if stat in f[a]:
+                if stat in g:
                     for i in range(2):
-                        if i >= f[a][stat].shape[0]:
+                        if i >= g[stat].shape[0]:
                             continue
                         summ[stat+str(2*i)] = {
-                            'k': f[a]['Bk_k123'][:],
-                            'value': f[a][stat][i, :],
-                            'nbar': f[a].attrs['nbar'],
-                            'log10nbar': f[a].attrs['log10nbar'],
-                            'a_loaded': a}
+                            'k': g['Bk_k123'][:],
+                            'value': g[stat][i, :],
+                            'nbar': g.attrs['nbar'],
+                            'log10nbar': g.attrs['log10nbar'],
+                            'a_loaded': a,
+                        }
     except (OSError, KeyError):
         return {}
     return summ
@@ -121,7 +128,6 @@ def load_lc_Bk(diag_file):
     summ = {}
     try:
         with h5py.File(diag_file, 'r') as f:
-            # load the summaries
             for stat in ['Bk', 'Qk']:
                 if stat in f:
                     for i in range(1):  # just monopole
@@ -131,7 +137,7 @@ def load_lc_Bk(diag_file):
                             'nbar': f.attrs['nbar'],
                             'log10nbar': f.attrs['log10nbar'],
                             'nz': f['nz'][:],
-                            'nz_bins': f['nz_bins'][:]
+                            'nz_bins': f['nz_bins'][:],
                         }
     except (OSError, KeyError):
         return {}
@@ -147,6 +153,16 @@ def _filter_Pk(X, kmin, kmax):
     # filter kmin and kmax
     return np.array(
         [x['value'][_is_in_kminmax(x['k'], kmin, kmax)] for x in X])
+
+
+def _get_Nmodes_Pk(data, kmin, kmax):
+    # Extract Nmodes for the k-bins that survive the kmin/kmax cut.
+    # Nmodes is the same for all sims (fixed grid), so we only need one entry.
+    nmodes = data[0].get('Nmodes', None)
+    if nmodes is None:
+        return None
+    k = data[0]['k']
+    return nmodes[_is_in_kminmax(k, kmin, kmax)]
 
 
 def _get_nbar(data):
@@ -184,13 +200,50 @@ def _get_log10nz(data):
     return binned_nz_logged  # shape: (num_entries, num_bins*num_repeat)
 
 
+def rebin_Pk_to_length(X, max_length, Nmodes=None):
+    """Coarsen Pk from shape (N_sims, N) to at most (N_sims, max_length).
+
+    Groups consecutive k-bins and averages within each group, weighted by
+    Nmodes (total Fourier mode count per bin). Falls back to uniform averaging
+    if Nmodes is None (e.g. old files without Pk_Nmodes saved).
+    """
+    N = X.shape[1]
+    if N <= max_length:
+        return X
+    group_size = int(np.ceil(N / max_length))
+    N_trimmed = (N // group_size) * group_size
+    X_t = X[:, :N_trimmed].reshape(X.shape[0], -1, group_size)  # (N_sims, n_out, group)
+    if Nmodes is not None:
+        w = Nmodes[:N_trimmed].reshape(-1, group_size)           # (n_out, group)
+        return np.einsum('sog,og->so', X_t, w) / w.sum(axis=1)
+    return X_t.mean(axis=2)
+
+
+def rebin_Bk_to_length(X, max_length):
+    """Coarsen Bk from shape (N_sims, N_triangles) to at most (N_sims, max_length).
+
+    Groups consecutive triangles and averages uniformly within each group.
+    NOTE: this is approximate — the exact weight per triangle is the number of
+    fundamental-mode triplets in the bin, which is not currently saved. Uniform
+    averaging is a reasonable substitute since B(k) is smooth, but it is not
+    the minimum-variance estimate. Order also matters: this must be called on
+    raw B(k) before signed_log so that mean(B) is averaged rather than mean(log B).
+    """
+    N = X.shape[1]
+    if N <= max_length:
+        return X
+    group_size = int(np.ceil(N / max_length))
+    N_trimmed = (N // group_size) * group_size
+    return X[:, :N_trimmed].reshape(X.shape[0], -1, group_size).mean(axis=2)
+
+
 def signed_log(x, base=10):
     # Compute the signed logarithm of x (for negative values)
     return np.sign(x) * np.log1p(np.abs(x)) / np.log(base)
 
 
 def preprocess_Pk(data, kmin, kmax, norm=None, correct_shot=False,
-                  loglinear_start_idx=None):
+                  loglinear_start_idx=None, max_length=None):
     # process Pk: filtering for k's, normalizing, and flattening
 
     X = _filter_Pk(data, kmin, kmax)
@@ -198,9 +251,18 @@ def preprocess_Pk(data, kmin, kmax, norm=None, correct_shot=False,
     if norm is None:  # monopole case
         if correct_shot:
             X -= 1./_get_nbar(data)  # subtract shot noise
+        # Rebin on raw P(k) before log so mode-weighted averaging is exact:
+        # mean(log P) != log(mean(P)), so order matters here.
+        if max_length is not None:
+            Nmodes = _get_Nmodes_Pk(data, kmin, kmax)
+            X = rebin_Pk_to_length(X, max_length, Nmodes)
         X = signed_log(X)
     else:  # higher multipoles normalized by monopole
         Xnorm = _filter_Pk(norm, kmin, kmax)
+        if max_length is not None:
+            Nmodes = _get_Nmodes_Pk(data, kmin, kmax)
+            X = rebin_Pk_to_length(X, max_length, Nmodes)
+            Xnorm = rebin_Pk_to_length(Xnorm, max_length, Nmodes)
         X /= Xnorm
 
     if loglinear_start_idx is not None:
@@ -267,29 +329,30 @@ def _filter_Bk(X, kmin, kmax, equilateral=False, squeezed=False,
 
 def preprocess_Bk(data, kmin, kmax, norm=None,
                   mode=None,  # None, Eq, Sq, SS, or Is
-                  correct_shot=False):
+                  correct_shot=False, max_length=None):
     # process Bk: filtering for k's, normalizing, and flattening
-    X = _filter_Bk(
-        data, kmin, kmax,
+    filter_kwargs = dict(
         equilateral=(mode == 'Eq'),
         squeezed=(mode == 'Sq'),
         subsampled=(mode == 'Ss'),
-        isoceles=(mode == 'Is')
+        isoceles=(mode == 'Is'),
     )
+    X = _filter_Bk(data, kmin, kmax, **filter_kwargs)
 
     if correct_shot:  # Eq. 44 arxiv:1610.06585
         pass  # not implemented because I'm not sure its right
 
     if norm is None:  # monopole case
+        # Rebin before log: mean(log B) != log(mean(B)), so order matters.
+        # Weighting is uniform (approximate) — see rebin_Bk_to_length docstring.
+        if max_length is not None:
+            X = rebin_Bk_to_length(X, max_length)
         X = signed_log(X)
     else:  # higher multipoles normalized by monopole
-        Xnorm = _filter_Bk(
-            norm, kmin, kmax,
-            equilateral=(mode == 'Eq'),
-            squeezed=(mode == 'Sq'),
-            subsampled=(mode == 'Ss'),
-            isoceles=(mode == 'Is')
-        )
+        Xnorm = _filter_Bk(norm, kmin, kmax, **filter_kwargs)
+        if max_length is not None:
+            X = rebin_Bk_to_length(X, max_length)
+            Xnorm = rebin_Bk_to_length(Xnorm, max_length)
         X /= Xnorm
 
     return np.nan_to_num(X, nan=0.0).reshape(len(X), -1)

--- a/cmass/infer/preprocess.py
+++ b/cmass/infer/preprocess.py
@@ -31,7 +31,8 @@ from ..utils import get_source_path, timing_decorator, clean_up
 from ..nbody.tools import parse_nbody_config
 from .tools import split_experiments
 from .loaders import (
-    preprocess_Pk, preprocess_Bk, _construct_hod_prior, _construct_noise_prior,
+    preprocess_Pk, preprocess_Bk,
+    _construct_hod_prior, _construct_noise_prior,
     _load_single_simulation_summaries, _get_log10nbar, _get_log10nz)
 
 
@@ -180,6 +181,7 @@ def run_preprocessing(summaries, parameters, ids, hodprior, noiseprior,
     name = '+'.join(exp.summary)
     kmin_list = exp.kmin if 'kmin' in exp else [0.]
     kmax_list = exp.kmax if 'kmax' in exp else [0.4]
+    max_length = exp.max_length if 'max_length' in exp else {}
 
     for kmin in kmin_list:
         for kmax in kmax_list:
@@ -206,16 +208,26 @@ def run_preprocessing(summaries, parameters, ids, hodprior, noiseprior,
                         x, kmin=kmin, kmax=kmax,
                         norm=None if '0' in base else summaries[norm_key],
                         correct_shot=cfg.infer.correct_shot,
-                        loglinear_start_idx=cfg.infer.loglinear_start_idx
+                        loglinear_start_idx=cfg.infer.loglinear_start_idx,
+                        max_length=max_length.get(summ, None)
                     )
+                    if summ in max_length:
+                        logging.info(
+                            f'Rebinned {summ} to {x.shape[1]} bins '
+                            f'(max_length={max_length[summ]})')
                 elif ('Bk' in summ) or ('Qk' in summ):
                     norm_key = base[:-1] + '0'  # monopole (Bk0 or zBk0)
                     x = preprocess_Bk(
                         x, kmin=kmin, kmax=kmax,
                         norm=None if '0' in base else summaries[norm_key],
                         mode=tag,
-                        correct_shot=cfg.infer.correct_shot  # doesn't work currently
+                        correct_shot=cfg.infer.correct_shot,  # doesn't work currently
+                        max_length=max_length.get(summ, None)
                     )
+                    if summ in max_length:
+                        logging.info(
+                            f'Rebinned {summ} to {x.shape[1]} triangles '
+                            f'(max_length={max_length[summ]})')
                 else:
                     raise NotImplementedError  # TODO: implement other summaries
                 xs.append((summ, x))

--- a/cmass/infer/preprocess.py
+++ b/cmass/infer/preprocess.py
@@ -181,7 +181,6 @@ def run_preprocessing(summaries, parameters, ids, hodprior, noiseprior,
     name = '+'.join(exp.summary)
     kmin_list = exp.kmin if 'kmin' in exp else [0.]
     kmax_list = exp.kmax if 'kmax' in exp else [0.4]
-    max_length = exp.max_length if 'max_length' in exp else {}
 
     for kmin in kmin_list:
         for kmax in kmax_list:
@@ -209,12 +208,7 @@ def run_preprocessing(summaries, parameters, ids, hodprior, noiseprior,
                         norm=None if '0' in base else summaries[norm_key],
                         correct_shot=cfg.infer.correct_shot,
                         loglinear_start_idx=cfg.infer.loglinear_start_idx,
-                        max_length=max_length.get(summ, None)
                     )
-                    if summ in max_length:
-                        logging.info(
-                            f'Rebinned {summ} to {x.shape[1]} bins '
-                            f'(max_length={max_length[summ]})')
                 elif ('Bk' in summ) or ('Qk' in summ):
                     norm_key = base[:-1] + '0'  # monopole (Bk0 or zBk0)
                     x = preprocess_Bk(
@@ -222,12 +216,7 @@ def run_preprocessing(summaries, parameters, ids, hodprior, noiseprior,
                         norm=None if '0' in base else summaries[norm_key],
                         mode=tag,
                         correct_shot=cfg.infer.correct_shot,  # doesn't work currently
-                        max_length=max_length.get(summ, None)
                     )
-                    if summ in max_length:
-                        logging.info(
-                            f'Rebinned {summ} to {x.shape[1]} triangles '
-                            f'(max_length={max_length[summ]})')
                 else:
                     raise NotImplementedError  # TODO: implement other summaries
                 xs.append((summ, x))

--- a/cmass/infer/preprocess.py
+++ b/cmass/infer/preprocess.py
@@ -169,9 +169,10 @@ def run_preprocessing(summaries, parameters, ids, hodprior, noiseprior,
 
     # check that there's data
     for summ in exp.summary:
-        for tag in ["Eq", "Sq", "Ss", "Is"]:
+        for tag in ["Eq", "Sq", "Ss", "Is", ""]:
             if tag in summ:
                 summ = summ.replace(tag, "")
+                break
         if summ in ['nbar', 'nz']:  # these come for free with any summaries
             continue
         if (summ not in summaries) or (len(summaries[summ]) == 0):
@@ -194,7 +195,7 @@ def run_preprocessing(summaries, parameters, ids, hodprior, noiseprior,
                     continue  # we handle these separately
 
                 base = summ
-                for tag in ["Eq", "Sq", "Ss",  "Is"]:
+                for tag in ["Eq", "Sq", "Ss",  "Is", ""]:
                     if tag in summ:
                         base = base.replace(tag, "")
                         break


### PR DESCRIPTION
## Summary

- **Fix three bugs** in `diagnostics/calculations.py`: `get_redshift_space_pos` and `get_box_catalogue_rsd` were passing `h` (a float) instead of a `cosmo` object to `RSL.pos_redshift_space`, causing incorrect RSD displacements; `calcBk_bfast` was returning `k123` (the full triangle array) as the 1D power spectrum k-array instead of `np.unique(k123)`.
- **Fix bug** in `infer/preprocess.py`: mode=tag could be incorrect when the summary name contains no tag (Eq/Sq/Ss/Is). In that case the preceding for tag in ... loop completes without break, leaving tag == "Is", so Bk/Qk preprocessing was accidentally restricted to isosceles triangles rather than the default (all valid triangles).
- **Standardize k-binning** so all summary statistics use a fixed physical grid regardless of box size (`K_MIN=0.01`, `DK_PK=0.01`, `DK_BK=0.04`, `K_MAX_BK=0.40` h/Mpc). Previously, PolyBin B(k) bins scaled with k_F = 2π/L, causing the data vector to grow with volume (e.g. 9880 triangles at 3 Gpc/h vs. 220 now). Fixed bins are required for SBI, where the data vector must have consistent meaning and length across simulations.
- **Mode-weighted rebinning for P(k)**: pylians internally bins at k_F, which varies with volume. The new `rebin_pk` function maps these fine bins onto the fixed grid using Nmodes-weighted averaging — the statistically correct weight since bins with more modes have lower variance.
- **Refactor `_filter_Bk`** in `loaders.py`: extract mask logic into `_get_Bk_mask` to eliminate duplicated filter kwargs.
- **Remove post-diagnostics rebinning**: an intermediate version of this PR added infrastructure to optionally rebin P(k) and B(k) to a configurable `max_length` in the inference preprocessing step. After consideration, this was removed — approximate post-hoc rebinning is not exact (mean(log P) ≠ log(mean(P))), and the fixed k-grid at computation time is the right solution. If different binning is needed for a future experiment, summaries will be recomputed from scratch.

## Data vector sizes (per multipole)

| | 1 Gpc/h old | 2 Gpc/h old | 3 Gpc/h old | All volumes new |
|---|---|---|---|---|
| P(k) bins | 64 | 128 | 192 | **40** |
| B(k) triangles | 364 | 2925 | 9880 | **220** |
