### PR TITLE
Summary-dependent kmax cuts in `cmass.infer`

### DIFF
--- a/cmass/conf/infer/default.yaml
+++ b/cmass/conf/infer/default.yaml
@@ -13,6 +13,9 @@ correct_shot: true  # whether to correct for shot noise when normalizing
 
 tracer: halo      # tracer to use for inference
 
+# Each kmax entry is a float (applied to all summaries) or a mapping keyed by
+# summary family (zPk, zQk, ...), exact name (zPk4), or 'default'.
+# See infer/mixk.yaml. kmin is always a scalar.
 experiments:
   - summary: [Pk0]   # monopole
     kmin: [0., 0.02]

--- a/cmass/conf/infer/mixk.yaml
+++ b/cmass/conf/infer/mixk.yaml
@@ -1,0 +1,28 @@
+defaults:
+  - simple
+  - _self_
+
+# Example of summary-dependent kmax cuts.
+#
+# Each entry of `kmax` is either:
+#   - a float, applied to every summary (legacy behaviour), or
+#   - a mapping, resolved per summary in order of decreasing specificity:
+#       exact name (zPk4) -> family (zPk, zQk, zEqBk) -> family without the
+#       triangle tag (zEqQk -> zQk) -> 'default'.
+#     A summary with no matching key and no 'default' raises.
+#
+# `kmin` remains a scalar, applied to all summaries.
+#
+# Output directories: a float kmax gives the usual kmin-0.0_kmax-0.4; a mapping
+# gives kmin-0.0_kmax-<key>-<val>.<key>-<val>... with keys sorted.
+
+experiments:
+  - summary: [zPk0, zPk2, zPk4, zQk0]
+    kmin: [0.]
+    kmax:
+      - 0.4                    # uniform cut, as before
+      - {zPk: 0.6, zQk: 0.2}   # P(k) to 0.6, Q(k) only to 0.2
+  - summary: [zPk0, zPk2, zPk4, zBk0]
+    kmin: [0.]
+    kmax:
+      - {zPk: 0.6, zPk4: 0.3, default: 0.2}

--- a/cmass/conf/infer/mixk.yaml
+++ b/cmass/conf/infer/mixk.yaml
@@ -14,7 +14,8 @@ defaults:
 # `kmin` remains a scalar, applied to all summaries.
 #
 # Output directories: a float kmax gives the usual kmin-0.0_kmax-0.4; a mapping
-# gives kmin-0.0_kmax-<key>-<val>.<key>-<val>... with keys sorted.
+# gives kmin-0.0_kmax-<key>=<val>__<key>=<val>... with keys sorted ('default'
+# shortened to 'def'), e.g. kmin-0.0_kmax-def=0.2__zPk=0.6__zPk4=0.3.
 
 experiments:
   - summary: [zPk0, zPk2, zPk4, zQk0]

--- a/cmass/infer/optuna.py
+++ b/cmass/infer/optuna.py
@@ -25,7 +25,7 @@ from .train import (load_preprocessed_data,
                     evaluate_posterior)
 from ..nbody.tools import parse_nbody_config
 from ..utils import timing_decorator, clean_up
-from .tools import split_experiments
+from .tools import split_experiments, iter_kcuts, kcut_dirname
 
 
 def objective(trial, cfg: DictConfig,
@@ -142,9 +142,6 @@ def run_experiment(exp, cfg, model_path):
     assert len(exp.summary) > 0, 'No summaries provided for inference'
     name = '+'.join(exp.summary)
 
-    kmin_list = exp.kmin if 'kmin' in exp else [0.]
-    kmax_list = exp.kmax if 'kmax' in exp else [0.4]
-
     if cfg.infer.cross_val:
         logging.info('Optuna objective uses cross-validation.')
         objective_fn = objective_cval
@@ -156,49 +153,48 @@ def run_experiment(exp, cfg, model_path):
         'validation_smoothing_method', 'none').lower()
     ema_decay = cfg.infer.get('ema_decay', 0.9)
 
-    for kmin in kmin_list:
-        for kmax in kmax_list:
-            logging.info(
-                f'Running training for {name} with {kmin} <= k <= {kmax}')
-            exp_path = join(model_path, f'kmin-{kmin}_kmax-{kmax}')
+    for kmin, kmax in iter_kcuts(exp):
+        logging.info(
+            f'Running training for {name} with {kmin} <= k <= {kmax}')
+        exp_path = join(model_path, kcut_dirname(kmin, kmax))
 
-            # load training/test data
-            (x_train, theta_train, ids_train,
-             x_val, theta_val, ids_val,
-             x_test, theta_test, ids_test,
-             hodprior, noiseprior,
-             startidx) = load_preprocessed_data(exp_path)
+        # load training/test data
+        (x_train, theta_train, ids_train,
+         x_val, theta_val, ids_val,
+         x_test, theta_test, ids_test,
+         hodprior, noiseprior,
+         startidx) = load_preprocessed_data(exp_path)
 
-            cv_args = []
-            if cfg.infer.cross_val:
-                cv_args = (cfg.infer.n_splits, ids_train, ids_val, ids_test)
+        cv_args = []
+        if cfg.infer.cross_val:
+            cv_args = (cfg.infer.n_splits, ids_train, ids_val, ids_test)
 
-            logging.info(
-                f'Split: {len(x_train)} training, {len(x_val)} validation, '
-                f'{len(x_test)} testing')
+        logging.info(
+            f'Split: {len(x_train)} training, {len(x_val)} validation, '
+            f'{len(x_test)} testing')
 
-            # run hyperparameter optimization
-            logging.info('Running hyperparameter optimization...')
-            study = setup_optuna(
-                exp_path, name, cfg.infer.n_startup_trials)
-            study.optimize(
-                lambda trial: objective_fn(
-                    trial, cfg, x_train, theta_train,
-                    x_val, theta_val, x_test, theta_test,
-                    hodprior, noiseprior,
-                    *cv_args,
-                    startidx,
-                    validation_smoothing_method=validation_smoothing_method,
-                    ema_decay=ema_decay),
-                n_trials=cfg.infer.n_trials,
-                n_jobs=1,
-                timeout=60*60*24,  # max 24 hours
-                show_progress_bar=False,
-                gc_after_trial=True
-            )
-            # NOTE: n_jobs>1 doesn't seem to speed things up much,
-            # It seems processes are fighting for threads.
-            # Instead, we parallelize via SLURM
+        # run hyperparameter optimization
+        logging.info('Running hyperparameter optimization...')
+        study = setup_optuna(
+            exp_path, name, cfg.infer.n_startup_trials)
+        study.optimize(
+            lambda trial: objective_fn(
+                trial, cfg, x_train, theta_train,
+                x_val, theta_val, x_test, theta_test,
+                hodprior, noiseprior,
+                *cv_args,
+                startidx,
+                validation_smoothing_method=validation_smoothing_method,
+                ema_decay=ema_decay),
+            n_trials=cfg.infer.n_trials,
+            n_jobs=1,
+            timeout=60*60*24,  # max 24 hours
+            show_progress_bar=False,
+            gc_after_trial=True
+        )
+        # NOTE: n_jobs>1 doesn't seem to speed things up much,
+        # It seems processes are fighting for threads.
+        # Instead, we parallelize via SLURM
 
 
 @timing_decorator

--- a/cmass/infer/preprocess.py
+++ b/cmass/infer/preprocess.py
@@ -29,7 +29,7 @@ import joblib
 
 from ..utils import get_source_path, timing_decorator, clean_up
 from ..nbody.tools import parse_nbody_config
-from .tools import split_experiments
+from .tools import split_experiments, iter_kcuts, kcut_dirname, resolve_kmax
 from .loaders import (
     preprocess_Pk, preprocess_Bk,
     _construct_hod_prior, _construct_noise_prior,
@@ -182,149 +182,149 @@ def run_preprocessing(summaries, parameters, ids, hodprior, noiseprior,
             return
 
     name = '+'.join(exp.summary)
-    kmin_list = exp.kmin if 'kmin' in exp else [0.]
-    kmax_list = exp.kmax if 'kmax' in exp else [0.4]
 
-    for kmin in kmin_list:
-        for kmax in kmax_list:
+    for kmin, kmax in iter_kcuts(exp):
+        logging.info(
+            f'Running preprocessing for {name} with {kmin} <= k <= {kmax}')
+        exp_path = join(model_path, kcut_dirname(kmin, kmax))
+        xs = []
+        for summ in exp.summary:
+            # Handle all the different summaries
+            if summ in ['nbar', 'nz']:
+                continue  # we handle these separately
+
+            base = summ
+            for tag in ["Eq", "Sq", "Ss",  "Is", ""]:
+                if tag in summ:
+                    base = base.replace(tag, "")
+                    break
+
+            # kmax may differ between summaries (e.g. Pk to 0.6, Bk to 0.2)
+            skmax = resolve_kmax(kmax, summ)
+
+            x, theta, id = summaries[base], parameters[base], ids[base]
+            # Preprocess the summaries
+            if 'Pk' in summ:
+                norm_key = base[:-1] + '0'  # monopole (Pk0 or zPk0)
+                x = preprocess_Pk(
+                    x, kmin=kmin, kmax=skmax,
+                    norm=None if '0' in base else summaries[norm_key],
+                    correct_shot=cfg.infer.correct_shot,
+                    loglinear_start_idx=cfg.infer.loglinear_start_idx,
+                )
+            elif ('Bk' in summ) or ('Qk' in summ):
+                norm_key = base[:-1] + '0'  # monopole (Bk0 or zBk0)
+                x = preprocess_Bk(
+                    x, kmin=kmin, kmax=skmax,
+                    norm=None if '0' in base else summaries[norm_key],
+                    mode=tag,
+                    correct_shot=cfg.infer.correct_shot,  # doesn't work currently
+                )
+            else:
+                raise NotImplementedError  # TODO: implement other summaries
+            xs.append((summ, x))
+        if 'nz' in exp.summary:  # add n(z)
+            xs.append(('nz', _get_log10nz(summaries['Pk0'])))
+        if 'nbar' in exp.summary:  # add nbar
+            xs.append(('nbar', _get_log10nbar(summaries['Pk0'])))
+
+        labels, xs = zip(*xs)
+        if not np.all([len(x) == len(xs[0]) for x in xs]):
+            raise ValueError(
+                f'Inconsistent lengths of summaries for {name}. Check that all '
+                'summaries have been computed for the same simulations.')
+        startidx = np.cumsum([0] + [x.shape[1] for x in xs])
+        x = np.concatenate(xs, axis=-1)
+
+        # noise out summaries that are not Pk0 or zPk0
+        if cfg.infer.get('test_noised_summs', False):
             logging.info(
-                f'Running preprocessing for {name} with {kmin} <= k <= {kmax}')
-            exp_path = join(model_path, f'kmin-{kmin}_kmax-{kmax}')
-            xs = []
-            for summ in exp.summary:
-                # Handle all the different summaries
-                if summ in ['nbar', 'nz']:
-                    continue  # we handle these separately
+                "TESTING: Noise out all summaries that are not Pk0 or zPk0")
+            for i, label in enumerate(labels):
+                if label not in ['Pk0', 'zPk0']:
+                    logging.info(f"Noise out summary: {label}")
+                    start, end = startidx[i], startidx[i+1]
+                    x[:, start:end] = np.random.standard_normal(
+                        size=(x.shape[0], end-start)
+                    ).astype(x.dtype)
 
-                base = summ
-                for tag in ["Eq", "Sq", "Ss",  "Is", ""]:
-                    if tag in summ:
-                        base = base.replace(tag, "")
-                        break
+        # split train/test
+        ((x_train, x_val, x_test), (theta_train, theta_val, theta_test),
+         (ids_train, ids_val, ids_test)) = split_train_val_test(
+            x, theta, id,
+            cfg.infer.val_frac, cfg.infer.test_frac, cfg.infer.seed)
+        logging.info(f'Split: {len(x_train)} training, '
+                     f'{len(x_val)} validation, {len(x_test)} testing')
 
-                x, theta, id = summaries[base], parameters[base], ids[base]
-                # Preprocess the summaries
-                if 'Pk' in summ:
-                    norm_key = base[:-1] + '0'  # monopole (Pk0 or zPk0)
-                    x = preprocess_Pk(
-                        x, kmin=kmin, kmax=kmax,
-                        norm=None if '0' in base else summaries[norm_key],
-                        correct_shot=cfg.infer.correct_shot,
-                        loglinear_start_idx=cfg.infer.loglinear_start_idx,
-                    )
-                elif ('Bk' in summ) or ('Qk' in summ):
-                    norm_key = base[:-1] + '0'  # monopole (Bk0 or zBk0)
-                    x = preprocess_Bk(
-                        x, kmin=kmin, kmax=kmax,
-                        norm=None if '0' in base else summaries[norm_key],
-                        mode=tag,
-                        correct_shot=cfg.infer.correct_shot,  # doesn't work currently
-                    )
-                else:
-                    raise NotImplementedError  # TODO: implement other summaries
-                xs.append((summ, x))
-            if 'nz' in exp.summary:  # add n(z)
-                xs.append(('nz', _get_log10nz(summaries['Pk0'])))
-            if 'nbar' in exp.summary:  # add nbar
-                xs.append(('nbar', _get_log10nbar(summaries['Pk0'])))
+        # Create output directory
+        logging.info(f'Saving training/test data to {exp_path}')
+        os.makedirs(exp_path, exist_ok=True)
 
-            labels, xs = zip(*xs)
-            if not np.all([len(x) == len(xs[0]) for x in xs]):
-                raise ValueError(
-                    f'Inconsistent lengths of summaries for {name}. Check that all '
-                    'summaries have been computed for the same simulations.')
-            startidx = np.cumsum([0] + [x.shape[1] for x in xs])
-            x = np.concatenate(xs, axis=-1)
+        # Precompress summaries
+        if cfg.infer.pca_features is not None and cfg.infer.pca_features > 0:
+            logging.info(
+                f"Precompressing with PCA to {cfg.infer.pca_features} features")
+            # Standardize the features
+            scaler = StandardScaler()
+            scaler.fit(x_train)
+            x_train = scaler.transform(x_train)
+            x_val = scaler.transform(x_val)
+            x_test = scaler.transform(x_test)
 
-            # noise out summaries that are not Pk0 or zPk0
-            if cfg.infer.get('test_noised_summs', False):
-                logging.info(
-                    "TESTING: Noise out all summaries that are not Pk0 or zPk0")
-                for i, label in enumerate(labels):
-                    if label not in ['Pk0', 'zPk0']:
-                        logging.info(f"Noise out summary: {label}")
-                        start, end = startidx[i], startidx[i+1]
-                        x[:, start:end] = np.random.standard_normal(
-                            size=(x.shape[0], end-start)
-                        ).astype(x.dtype)
+            # PCA compress the features
+            pca = PCA(n_components=cfg.infer.pca_features)
+            pca.fit(x_train)
+            x_train = pca.transform(x_train)
+            x_val = pca.transform(x_val)
+            x_test = pca.transform(x_test)
+            joblib.dump((scaler, pca), join(exp_path, 'pca.pkl'))
 
-            # split train/test
-            ((x_train, x_val, x_test), (theta_train, theta_val, theta_test),
-             (ids_train, ids_val, ids_test)) = split_train_val_test(
-                x, theta, id,
-                cfg.infer.val_frac, cfg.infer.test_frac, cfg.infer.seed)
-            logging.info(f'Split: {len(x_train)} training, '
-                         f'{len(x_val)} validation, {len(x_test)} testing')
+        # save training/test data
+        with open(join(exp_path, 'config.yaml'), 'w') as f:
+            OmegaConf.save(cfg, f)
+        np.save(join(exp_path, 'x_train.npy'), x_train)
+        np.save(join(exp_path, 'x_val.npy'), x_val)
+        np.save(join(exp_path, 'x_test.npy'), x_test)
+        np.save(join(exp_path, 'theta_train.npy'), theta_train)
+        np.save(join(exp_path, 'theta_val.npy'), theta_val)
+        np.save(join(exp_path, 'theta_test.npy'), theta_test)
+        np.save(join(exp_path, 'ids_train.npy'), ids_train)
+        np.save(join(exp_path, 'ids_val.npy'), ids_val)
+        np.save(join(exp_path, 'ids_test.npy'), ids_test)
 
-            # Create output directory
-            logging.info(f'Saving training/test data to {exp_path}')
-            os.makedirs(exp_path, exist_ok=True)
+        # Save split-wise aux arrays
+        id_arr = np.asarray(id)
+        train_mask = np.isin(id_arr, ids_train)
+        val_mask = np.isin(id_arr, ids_val)
+        test_mask = np.isin(id_arr, ids_test)
 
-            # Precompress summaries
-            if cfg.infer.pca_features is not None and cfg.infer.pca_features > 0:
-                logging.info(
-                    f"Precompressing with PCA to {cfg.infer.pca_features} features")
-                # Standardize the features
-                scaler = StandardScaler()
-                scaler.fit(x_train)
-                x_train = scaler.transform(x_train)
-                x_val = scaler.transform(x_val)
-                x_test = scaler.transform(x_test)
+        # number densities
+        nbar = np.asarray(_get_log10nbar(summaries["Pk0"]))[:, -1]
+        np.save(join(exp_path, "nbar_train.npy"), nbar[train_mask])
+        np.save(join(exp_path, "nbar_val.npy"), nbar[val_mask])
+        np.save(join(exp_path, "nbar_test.npy"), nbar[test_mask])
 
-                # PCA compress the features
-                pca = PCA(n_components=cfg.infer.pca_features)
-                pca.fit(x_train)
-                x_train = pca.transform(x_train)
-                x_val = pca.transform(x_val)
-                x_test = pca.transform(x_test)
-                joblib.dump((scaler, pca), join(exp_path, 'pca.pkl'))
+        if "noiseid" in summaries:
+            # noise indices
+            noise = np.asarray(summaries["noiseid"]).reshape(-1, 1)
+            np.save(join(exp_path, "noiseid_train.npy"), noise[train_mask])
+            np.save(join(exp_path, "noiseid_val.npy"), noise[val_mask])
+            np.save(join(exp_path, "noiseid_test.npy"), noise[test_mask])
 
-            # save training/test data
-            with open(join(exp_path, 'config.yaml'), 'w') as f:
-                OmegaConf.save(cfg, f)
-            np.save(join(exp_path, 'x_train.npy'), x_train)
-            np.save(join(exp_path, 'x_val.npy'), x_val)
-            np.save(join(exp_path, 'x_test.npy'), x_test)
-            np.save(join(exp_path, 'theta_train.npy'), theta_train)
-            np.save(join(exp_path, 'theta_val.npy'), theta_val)
-            np.save(join(exp_path, 'theta_test.npy'), theta_test)
-            np.save(join(exp_path, 'ids_train.npy'), ids_train)
-            np.save(join(exp_path, 'ids_val.npy'), ids_val)
-            np.save(join(exp_path, 'ids_test.npy'), ids_test)
+        with open(join(exp_path, 'x_startidx.txt'), 'w') as f:
+            f.write(','.join(labels) + '\n')
+            f.write(','.join(map(str, startidx.tolist())) + '\n')
+        if hodprior is not None:
+            np.savetxt(join(exp_path, 'hodprior.csv'), hodprior,
+                       delimiter=',', fmt='%s')
+        if noiseprior is not None:
+            with open(join(exp_path, 'noiseprior.yaml'), 'w') as f:
+                OmegaConf.save(noiseprior, f)
+        # np.savetxt(join(exp_path, 'param_names.txt'), names, fmt='%s')
 
-            # Save split-wise aux arrays
-            id_arr = np.asarray(id)
-            train_mask = np.isin(id_arr, ids_train)
-            val_mask = np.isin(id_arr, ids_val)
-            test_mask = np.isin(id_arr, ids_test)
-
-            # number densities
-            nbar = np.asarray(_get_log10nbar(summaries["Pk0"]))[:, -1]
-            np.save(join(exp_path, "nbar_train.npy"), nbar[train_mask])
-            np.save(join(exp_path, "nbar_val.npy"), nbar[val_mask])
-            np.save(join(exp_path, "nbar_test.npy"), nbar[test_mask])
-
-            if "noiseid" in summaries:
-                # noise indices
-                noise = np.asarray(summaries["noiseid"]).reshape(-1, 1)
-                np.save(join(exp_path, "noiseid_train.npy"), noise[train_mask])
-                np.save(join(exp_path, "noiseid_val.npy"), noise[val_mask])
-                np.save(join(exp_path, "noiseid_test.npy"), noise[test_mask])
-
-            with open(join(exp_path, 'x_startidx.txt'), 'w') as f:
-                f.write(','.join(labels) + '\n')
-                f.write(','.join(map(str, startidx.tolist())) + '\n')
-            if hodprior is not None:
-                np.savetxt(join(exp_path, 'hodprior.csv'), hodprior,
-                           delimiter=',', fmt='%s')
-            if noiseprior is not None:
-                with open(join(exp_path, 'noiseprior.yaml'), 'w') as f:
-                    OmegaConf.save(noiseprior, f)
-            # np.savetxt(join(exp_path, 'param_names.txt'), names, fmt='%s')
-
-            # initialize Optuna study (to avoid overwriting during parallelization)
-            if not isfile(join(exp_path, 'optuna_study.db')):
-                _ = setup_optuna(exp_path, name, cfg.infer.n_startup_trials)
+        # initialize Optuna study (to avoid overwriting during parallelization)
+        if not isfile(join(exp_path, 'optuna_study.db')):
+            _ = setup_optuna(exp_path, name, cfg.infer.n_startup_trials)
 
 
 @timing_decorator

--- a/cmass/infer/tools.py
+++ b/cmass/infer/tools.py
@@ -2,24 +2,94 @@
 
 import torch
 import io
+import os
 import pickle
 from torch.utils.data import TensorDataset, DataLoader
+from omegaconf import DictConfig
 import optuna
 from typing import List
 import numpy as np
 
 
+# Bispectrum triangle-configuration tags, stripped when resolving a summary's
+# k-cut family (e.g. zEqQk0 -> zQk).
+_BK_TAGS = ('Eq', 'Sq', 'Ss', 'Is')
+
+# Summaries which carry no k-dependence, and so take no k-cut.
+_KLESS_SUMMARIES = ('nbar', 'nz')
+
+
+def _is_mapping(kmax):
+    return isinstance(kmax, (dict, DictConfig))
+
+
+def _kcut_keys(summ):
+    """Candidate mapping keys for a summary, in decreasing specificity.
+
+    e.g. zEqQk0 -> ['zEqQk0', 'zEqQk', 'zQk', 'default']
+    """
+    keys = [summ]
+    family = summ.rstrip('0123456789')
+    if family and family != summ:
+        keys.append(family)
+    for tag in _BK_TAGS:
+        if tag in family:
+            keys.append(family.replace(tag, '', 1))
+            break
+    keys.append('default')
+    return keys
+
+
+def resolve_kmax(kmax, summ):
+    """Resolve the kmax cut for a single summary.
+
+    kmax is either a scalar (applied to every summary) or a mapping keyed by
+    summary family (Pk, zQk, ...), exact summary name (zPk4), or 'default'.
+    """
+    if not _is_mapping(kmax):
+        return kmax
+    for key in _kcut_keys(summ):
+        if key in kmax:
+            return kmax[key]
+    raise KeyError(
+        f'No kmax specified for summary {summ!r} in {dict(kmax)}. Provide a '
+        f'key matching one of {_kcut_keys(summ)[:-1]}, or a "default" key.')
+
+
+def kcut_dirname(kmin, kmax):
+    """Directory name encoding a k-cut.
+
+    Scalar kmax reproduces the legacy name verbatim (kmin-0.0_kmax-0.4).
+    Mapping kmax is encoded as kmin-0.0_kmax-zPk-0.6.zQk-0.2.
+    """
+    if _is_mapping(kmax):
+        kmax = '.'.join(f'{k}-{kmax[k]}' for k in sorted(kmax))
+    return f'kmin-{kmin}_kmax-{kmax}'
+
+
+def iter_kcuts(exp):
+    """Iterate over the (kmin, kmax) cuts of an experiment."""
+    kmin_list = exp.kmin if 'kmin' in exp else [0.]
+    kmax_list = exp.kmax if 'kmax' in exp else [0.4]
+    for kmin in kmin_list:
+        for kmax in kmax_list:
+            yield kmin, kmax
+
+
+def study_name_from_path(exp_path):
+    """Recover the optuna study name (the summary combination) from a path
+    of the form .../<tracer>/<summary>/<kcut>."""
+    return os.path.basename(os.path.dirname(exp_path.rstrip('/')))
+
+
 def split_experiments(exp_cfg):
     new_exps = []
     for exp in exp_cfg:
-        kmin_list = exp.kmin if 'kmin' in exp else [0.]
-        kmax_list = exp.kmax if 'kmax' in exp else [0.4]
-        for kmin in kmin_list:
-            for kmax in kmax_list:
-                new_exp = exp.copy()
-                new_exp.kmin = [kmin]
-                new_exp.kmax = [kmax]
-                new_exps.append(new_exp)
+        for kmin, kmax in iter_kcuts(exp):
+            new_exp = exp.copy()
+            new_exp.kmin = [kmin]
+            new_exp.kmax = [kmax]
+            new_exps.append(new_exp)
     return new_exps
 
 

--- a/cmass/infer/tools.py
+++ b/cmass/infer/tools.py
@@ -60,10 +60,13 @@ def kcut_dirname(kmin, kmax):
     """Directory name encoding a k-cut.
 
     Scalar kmax reproduces the legacy name verbatim (kmin-0.0_kmax-0.4).
-    Mapping kmax is encoded as kmin-0.0_kmax-zPk-0.6.zQk-0.2.
+    Mapping kmax is encoded as
+    kmin-0.0_kmax-def=0.2__zPk=0.6__zPk4=0.3 ('default' short as 'def').
     """
     if _is_mapping(kmax):
-        kmax = '.'.join(f'{k}-{kmax[k]}' for k in sorted(kmax))
+        kmax = '__'.join(
+            f'{"def" if k == "default" else k}={kmax[k]}'
+            for k in sorted(kmax))
     return f'kmin-{kmin}_kmax-{kmax}'
 
 
@@ -126,12 +129,13 @@ def select_top_trials(study: optuna.study.Study, n_nets: int) -> List[optuna.tri
     """
     trials = study.get_trials(
         deepcopy=False, states=[optuna.trial.TrialState.COMPLETE])
-    
+
     if len(trials) == 0:
         raise ValueError('No completed trials found in the study.')
-    
+
     trials = sorted(trials, key=lambda t: t.value, reverse=True)
     return trials[:n_nets]
+
 
 def log2_avg(A, s=0):
     A = np.asarray(A)

--- a/cmass/infer/train.py
+++ b/cmass/infer/train.py
@@ -24,7 +24,8 @@ import yaml
 import time
 import optuna
 
-from .tools import select_top_trials, split_experiments, prepare_loader
+from .tools import (select_top_trials, split_experiments, prepare_loader,
+                    iter_kcuts, kcut_dirname, study_name_from_path)
 from .hyperparameters import sample_hyperparameters_randomly
 from ..utils import timing_decorator, clean_up
 from ..nbody.tools import parse_nbody_config
@@ -418,57 +419,54 @@ def run_experiment(exp, cfg, model_path):
     assert len(exp.summary) > 0, 'No summaries provided for inference'
     name = '+'.join(exp.summary)
 
-    kmin_list = exp.kmin if 'kmin' in exp else [0.]
-    kmax_list = exp.kmax if 'kmax' in exp else [0.4]
     validation_smoothing_method = cfg.infer.get(
         'validation_smoothing_method', 'none')
     ema_decay = cfg.infer.get('ema_decay', 0.9)
 
-    for kmin in kmin_list:
-        for kmax in kmax_list:
-            logging.info(
-                f'Running training for {name} with {kmin} <= k <= {kmax}')
-            exp_path = join(model_path, f'kmin-{kmin}_kmax-{kmax}')
+    for kmin, kmax in iter_kcuts(exp):
+        logging.info(
+            f'Running training for {name} with {kmin} <= k <= {kmax}')
+        exp_path = join(model_path, kcut_dirname(kmin, kmax))
 
-            # load training/test data
-            (x_train, theta_train, ids_train,
-             x_val, theta_val, ids_val,
-             x_test, theta_test, ids_test,
-             hodprior, noiseprior,
-             startidx) = load_preprocessed_data(exp_path)
+        # load training/test data
+        (x_train, theta_train, ids_train,
+         x_val, theta_val, ids_val,
+         x_test, theta_test, ids_test,
+         hodprior, noiseprior,
+         startidx) = load_preprocessed_data(exp_path)
 
-            logging.info(
-                f'Split: {len(x_train)} training, {len(x_val)} validation, '
-                f'{len(x_test)} testing')
+        logging.info(
+            f'Split: {len(x_train)} training, {len(x_val)} validation, '
+            f'{len(x_test)} testing')
 
-            out_dir = join(exp_path, 'nets', f'net-{cfg.infer.net_index}')
-            logging.info(f'Saving models to {out_dir}')
+        out_dir = join(exp_path, 'nets', f'net-{cfg.infer.net_index}')
+        logging.info(f'Saving models to {out_dir}')
 
-            # run training
-            start = time.time()
-            posterior, histories = run_training(
-                x_train, theta_train, x_val, theta_val, out_dir=out_dir,
-                cfg=cfg, mcfg=cfg.net,
-                hodprior=hodprior, noiseprior=noiseprior,
-                start_idx=startidx,
-                validation_smoothing_method=validation_smoothing_method,
-                ema_decay=ema_decay,
-            )
-            end = time.time()
+        # run training
+        start = time.time()
+        posterior, histories = run_training(
+            x_train, theta_train, x_val, theta_val, out_dir=out_dir,
+            cfg=cfg, mcfg=cfg.net,
+            hodprior=hodprior, noiseprior=noiseprior,
+            start_idx=startidx,
+            validation_smoothing_method=validation_smoothing_method,
+            ema_decay=ema_decay,
+        )
+        end = time.time()
 
-            # Save the timing and metadata
-            with open(join(out_dir, 'timing.txt'), 'w') as f:
-                f.write(f'{end - start:.3f}')
-            with open(join(out_dir, 'model_config.yaml'), 'w') as f:
-                yaml.dump(OmegaConf.to_container(cfg.net, resolve=True), f)
+        # Save the timing and metadata
+        with open(join(out_dir, 'timing.txt'), 'w') as f:
+            f.write(f'{end - start:.3f}')
+        with open(join(out_dir, 'model_config.yaml'), 'w') as f:
+            yaml.dump(OmegaConf.to_container(cfg.net, resolve=True), f)
 
-            # plot training history
-            plot_training_history(histories, out_dir)
+        # plot training history
+        plot_training_history(histories, out_dir)
 
-            # evaluate the posterior and save to file
-            log_prob_test = evaluate_posterior(posterior, x_test, theta_test)
-            with open(join(out_dir, 'log_prob_test.txt'), 'w') as f:
-                f.write(f'{log_prob_test}\n')
+        # evaluate the posterior and save to file
+        log_prob_test = evaluate_posterior(posterior, x_test, theta_test)
+        with open(join(out_dir, 'log_prob_test.txt'), 'w') as f:
+            f.write(f'{log_prob_test}\n')
 
 
 def select_nets_retrain(exp_path, Nnets):
@@ -480,10 +478,10 @@ def select_nets_retrain(exp_path, Nnets):
     optunafile_cv = join(exp_path, 'optuna_study.db')
     storage_cv = f"sqlite:///{optunafile_cv}"
 
-    # hack not to pass the summary/summaries argument again, already in exp_path
+    # the summary combination is already encoded in exp_path
     study_cv = optuna.load_study(
         storage=storage_cv,
-        study_name=exp_path.split("/kmin")[0].split("/")[-1])
+        study_name=study_name_from_path(exp_path))
 
     # Load top Nnets architectures by test log prob
     top_trials = select_top_trials(study_cv, Nnets)
@@ -505,9 +503,6 @@ def run_retraining(exp, cfg, model_path):
     assert len(exp.summary) > 0, 'No summaries provided for inference'
     name = '+'.join(exp.summary)
 
-    kmin_list = exp.kmin if 'kmin' in exp else [0.]
-    kmax_list = exp.kmax if 'kmax' in exp else [0.4]
-
     Nnets = cfg.infer.Nnets
     if cfg.infer.precompress:
         train_fn = run_training_with_precompression
@@ -522,78 +517,77 @@ def run_retraining(exp, cfg, model_path):
         'validation_smoothing_method', 'none').lower()
     ema_decay = cfg.infer.get('ema_decay', 0.9)
 
-    for kmin in kmin_list:
-        for kmax in kmax_list:
-            logging.info(
-                f'Running training for {name} with {kmin} <= k <= {kmax}')
-            exp_path = join(model_path, f'kmin-{kmin}_kmax-{kmax}')
+    for kmin, kmax in iter_kcuts(exp):
+        logging.info(
+            f'Running training for {name} with {kmin} <= k <= {kmax}')
+        exp_path = join(model_path, kcut_dirname(kmin, kmax))
 
-            # Only select a subset of networks within the hyperparameter study
-            trial_numbers, net_configs = select_nets_retrain(exp_path, Nnets)
+        # Only select a subset of networks within the hyperparameter study
+        trial_numbers, net_configs = select_nets_retrain(exp_path, Nnets)
 
-            # If net_index is not None, select the net_index-th model, otherwise train all sequentially
-            if hasattr(cfg.infer, 'net_index') and cfg.infer.net_index is not None:
-                net_index = cfg.infer.net_index
-                if net_index < len(trial_numbers):
-                    logging.info(
-                        f"Selecting net index {net_index} from top {len(trial_numbers)} models.")
-                    trial_numbers = [trial_numbers[net_index]]
-                    net_configs = [net_configs[net_index]]
-                else:
-                    logging.warning(
-                        f"net_index {net_index} is out of bounds for top {len(trial_numbers)} models. Exiting.")
-                    return
-
-            for trial_number, config in zip(trial_numbers, net_configs):
-
-                out_dir = join(exp_path, "nets", f"net-{trial_number}")
-                os.makedirs(out_dir, exist_ok=True)
-
-                # if net is run and saved already, skip
-                if os.path.exists(join(out_dir, 'posterior.pkl')):
-                    logging.info(
-                        f"Net-{trial_number} already trained. Skipping.")
-                    continue
-
-                # load training/test data: we retrain on the original split
-                # from cmass.infer.preprocess
-                (x_train, theta_train, ids_train,
-                 x_val, theta_val, ids_val,
-                 x_test, theta_test, ids_test,
-                 hodprior, noiseprior,
-                 startidx) = load_preprocessed_data(exp_path)
-
+        # If net_index is not None, select the net_index-th model, otherwise train all sequentially
+        if hasattr(cfg.infer, 'net_index') and cfg.infer.net_index is not None:
+            net_index = cfg.infer.net_index
+            if net_index < len(trial_numbers):
                 logging.info(
-                    f'Split: {len(x_train)} training, {len(x_val)} validation, '
-                    f'{len(x_test)} testing')
+                    f"Selecting net index {net_index} from top {len(trial_numbers)} models.")
+                trial_numbers = [trial_numbers[net_index]]
+                net_configs = [net_configs[net_index]]
+            else:
+                logging.warning(
+                    f"net_index {net_index} is out of bounds for top {len(trial_numbers)} models. Exiting.")
+                return
 
-                mcfg = OmegaConf.create(config)
+        for trial_number, config in zip(trial_numbers, net_configs):
 
-                start = time.time()
-                posterior, histories = train_fn(
-                    x_train, theta_train, x_val, theta_val, out_dir=out_dir,
-                    cfg=cfg, mcfg=mcfg,
-                    hodprior=hodprior, noiseprior=noiseprior,
-                    start_idx=startidx,
-                    validation_smoothing_method=validation_smoothing_method,
-                    ema_decay=ema_decay
-                )
-                end = time.time()
+            out_dir = join(exp_path, "nets", f"net-{trial_number}")
+            os.makedirs(out_dir, exist_ok=True)
 
-                # Save the timing and metadata
-                with open(join(out_dir, 'timing.txt'), 'w') as f:
-                    f.write(f'{end - start:.3f}')
-                with open(join(out_dir, 'model_config.yaml'), 'w') as f:
-                    yaml.dump(OmegaConf.to_container(mcfg, resolve=True), f)
+            # if net is run and saved already, skip
+            if os.path.exists(join(out_dir, 'posterior.pkl')):
+                logging.info(
+                    f"Net-{trial_number} already trained. Skipping.")
+                continue
 
-                # plot training history
-                plot_training_history(histories, out_dir)
+            # load training/test data: we retrain on the original split
+            # from cmass.infer.preprocess
+            (x_train, theta_train, ids_train,
+             x_val, theta_val, ids_val,
+             x_test, theta_test, ids_test,
+             hodprior, noiseprior,
+             startidx) = load_preprocessed_data(exp_path)
 
-                # evaluate the posterior and save to file
-                log_prob_test = evaluate_posterior(
-                    posterior, x_test, theta_test)
-                with open(join(out_dir, 'log_prob_test.txt'), 'w') as f:
-                    f.write(f'{log_prob_test}\n')
+            logging.info(
+                f'Split: {len(x_train)} training, {len(x_val)} validation, '
+                f'{len(x_test)} testing')
+
+            mcfg = OmegaConf.create(config)
+
+            start = time.time()
+            posterior, histories = train_fn(
+                x_train, theta_train, x_val, theta_val, out_dir=out_dir,
+                cfg=cfg, mcfg=mcfg,
+                hodprior=hodprior, noiseprior=noiseprior,
+                start_idx=startidx,
+                validation_smoothing_method=validation_smoothing_method,
+                ema_decay=ema_decay
+            )
+            end = time.time()
+
+            # Save the timing and metadata
+            with open(join(out_dir, 'timing.txt'), 'w') as f:
+                f.write(f'{end - start:.3f}')
+            with open(join(out_dir, 'model_config.yaml'), 'w') as f:
+                yaml.dump(OmegaConf.to_container(mcfg, resolve=True), f)
+
+            # plot training history
+            plot_training_history(histories, out_dir)
+
+            # evaluate the posterior and save to file
+            log_prob_test = evaluate_posterior(
+                posterior, x_test, theta_test)
+            with open(join(out_dir, 'log_prob_test.txt'), 'w') as f:
+                f.write(f'{log_prob_test}\n')
 
 
 @timing_decorator

--- a/cmass/infer/train_nle.py
+++ b/cmass/infer/train_nle.py
@@ -37,7 +37,7 @@ from torch.utils.data import TensorDataset, DataLoader
 import matplotlib.pyplot as plt
 from tqdm import tqdm
 
-from .tools import split_experiments
+from .tools import split_experiments, iter_kcuts, kcut_dirname
 from ..utils import timing_decorator, clean_up
 from ..nbody.tools import parse_nbody_config
 
@@ -214,46 +214,42 @@ def main(cfg: DictConfig) -> None:
         name = '+'.join(exp.summary)
         save_path = join(model_dir, tracer, name)
 
-        kmin_list = exp.kmin if 'kmin' in exp else [0.]
-        kmax_list = exp.kmax if 'kmax' in exp else [0.4]
+        for kmin, kmax in iter_kcuts(exp):
+            log.info(
+                f'NLE training for {name} with {kmin} <= k <= {kmax}')
+            exp_path = join(save_path, kcut_dirname(kmin, kmax))
 
-        for kmin in kmin_list:
-            for kmax in kmax_list:
-                log.info(
-                    f'NLE training for {name} with {kmin} <= k <= {kmax}')
-                exp_path = join(save_path, f'kmin-{kmin}_kmax-{kmax}')
+            try:
+                x_train = np.load(join(exp_path, 'x_train.npy'))
+                theta_train = np.load(join(exp_path, 'theta_train.npy'))
+                x_val = np.load(join(exp_path, 'x_val.npy'))
+                theta_val = np.load(join(exp_path, 'theta_val.npy'))
+            except FileNotFoundError:
+                log.error(
+                    f'Missing preprocessed data in {exp_path}. '
+                    'Run cmass.infer.preprocess first.')
+                continue
 
-                try:
-                    x_train = np.load(join(exp_path, 'x_train.npy'))
-                    theta_train = np.load(join(exp_path, 'theta_train.npy'))
-                    x_val = np.load(join(exp_path, 'x_val.npy'))
-                    theta_val = np.load(join(exp_path, 'theta_val.npy'))
-                except FileNotFoundError:
-                    log.error(
-                        f'Missing preprocessed data in {exp_path}. '
-                        'Run cmass.infer.preprocess first.')
-                    continue
+            log.info(
+                f'x_train {x_train.shape}, theta_train {theta_train.shape}')
+            log.info(
+                f'x_val {x_val.shape}, theta_val {theta_val.shape}')
 
-                log.info(
-                    f'x_train {x_train.shape}, theta_train {theta_train.shape}')
-                log.info(
-                    f'x_val {x_val.shape}, theta_val {theta_val.shape}')
+            D_x = x_train.shape[1]
+            D_theta = theta_train.shape[1]
 
-                D_x = x_train.shape[1]
-                D_theta = theta_train.shape[1]
+            model = DiagonalGaussianNLE(
+                D_x, D_theta,
+                hidden_features=HIDDEN_FEATURES,
+                hidden_depth=HIDDEN_DEPTH,
+            ).to(device)
+            train_losses, val_losses = _train(
+                model, x_train, theta_train, x_val, theta_val,
+                device=device)
 
-                model = DiagonalGaussianNLE(
-                    D_x, D_theta,
-                    hidden_features=HIDDEN_FEATURES,
-                    hidden_depth=HIDDEN_DEPTH,
-                ).to(device)
-                train_losses, val_losses = _train(
-                    model, x_train, theta_train, x_val, theta_val,
-                    device=device)
-
-                _save(model, D_x, D_theta, join(exp_path, 'nle.pt'))
-                _plot_loss(
-                    train_losses, val_losses, join(exp_path, 'nle_loss.png'))
+            _save(model, D_x, D_theta, join(exp_path, 'nle.pt'))
+            _plot_loss(
+                train_losses, val_losses, join(exp_path, 'nle_loss.png'))
 
 
 if __name__ == "__main__":

--- a/cmass/infer/validate.py
+++ b/cmass/infer/validate.py
@@ -20,7 +20,8 @@ import shutil
 import optuna.visualization.matplotlib as vis
 from matplotlib import pyplot as plt
 
-from .tools import select_top_trials, split_experiments, load_posterior
+from .tools import (select_top_trials, split_experiments, load_posterior,
+                    iter_kcuts, kcut_dirname, study_name_from_path)
 from ..utils import timing_decorator, clean_up
 from ..nbody.tools import parse_nbody_config
 
@@ -105,10 +106,10 @@ def load_ensemble(exp_path, Nnets, weighted=True, plot=True, clean=False):
     optunafile_cv = join(exp_path, 'optuna_study.db')
     storage_cv = f"sqlite:///{optunafile_cv}"
 
-    # hack not to pass the summary/summaries argument again, already in exp_path
+    # the summary combination is already encoded in exp_path
     study_cv = optuna.load_study(
         storage=storage_cv,
-        study_name=exp_path.split("/kmin")[0].split("/")[-1])
+        study_name=study_name_from_path(exp_path))
 
     # Load top Nnets architectures by test log prob
     top_trials = select_top_trials(study_cv, Nnets)
@@ -161,54 +162,51 @@ def load_ensemble(exp_path, Nnets, weighted=True, plot=True, clean=False):
 def run_experiment(exp, cfg, model_path):
     assert len(exp.summary) > 0, 'No summaries provided for inference'
     name = '+'.join(exp.summary)
-    kmin_list = exp.kmin if 'kmin' in exp else [0.]
-    kmax_list = exp.kmax if 'kmax' in exp else [0.4]
 
-    for kmin in kmin_list:
-        for kmax in kmax_list:
-            logging.info(
-                f'Running validation for {name} with {kmin} <= k <= {kmax}')
-            exp_path = join(model_path, f'kmin-{kmin}_kmax-{kmax}')
+    for kmin, kmax in iter_kcuts(exp):
+        logging.info(
+            f'Running validation for {name} with {kmin} <= k <= {kmax}')
+        exp_path = join(model_path, kcut_dirname(kmin, kmax))
 
         # load test data
-            try:
-                if cfg.infer.testing.suite is None:
-                    logging.info(f'Loading test data from {exp_path}')
-                    x_test = np.load(join(exp_path, 'x_test.npy'))
-                    theta_test = np.load(join(exp_path, 'theta_test.npy'))
-                    out_path = exp_path
-                else:
-                    test_path = join(
-                        cfg.meta.wdir,
-                        cfg.infer.testing.suite, cfg.infer.testing.sim,
-                        'models', cfg.infer.tracer, name,
-                        f'kmin-{kmin}_kmax-{kmax}')
-                    logging.info(
-                        f'Loading external test data from {test_path}')
-                    x_test = np.load(join(test_path, 'x_test.npy'))
-                    theta_test = np.load(
-                        join(test_path, 'theta_test.npy'))
+        try:
+            if cfg.infer.testing.suite is None:
+                logging.info(f'Loading test data from {exp_path}')
+                x_test = np.load(join(exp_path, 'x_test.npy'))
+                theta_test = np.load(join(exp_path, 'theta_test.npy'))
+                out_path = exp_path
+            else:
+                test_path = join(
+                    cfg.meta.wdir,
+                    cfg.infer.testing.suite, cfg.infer.testing.sim,
+                    'models', cfg.infer.tracer, name,
+                    kcut_dirname(kmin, kmax))
+                logging.info(
+                    f'Loading external test data from {test_path}')
+                x_test = np.load(join(test_path, 'x_test.npy'))
+                theta_test = np.load(
+                    join(test_path, 'theta_test.npy'))
 
-                    out_path = join(exp_path, 'testing',
-                                    f'{cfg.infer.testing.suite}_{cfg.infer.testing.sim}')
-                    if not os.path.exists(out_path):
-                        os.makedirs(out_path)
+                out_path = join(exp_path, 'testing',
+                                f'{cfg.infer.testing.suite}_{cfg.infer.testing.sim}')
+                if not os.path.exists(out_path):
+                    os.makedirs(out_path)
 
-                names = ['Omega_m', 'Omega_b', 'h', 'n_s', 'sigma_8']
-                filepath = join(exp_path, 'hodprior.csv')
-                if cfg.infer.subselect_cosmo is not None:
-                    names = [names[i] for i in cfg.infer.subselect_cosmo]
-                if cfg.infer.include_hod and os.path.exists(filepath):
-                    hodprior = np.genfromtxt(
-                        filepath, delimiter=',', dtype=object)
-                    names += hodprior[:, 0].astype('str').tolist()
-                if cfg.infer.include_noise:
-                    names += ['noise_radial', 'noise_transverse']
-            except FileNotFoundError:
-                raise FileNotFoundError(
-                    f'Could not find test data for {name} with kmax={kmax}.'
-                    'Make sure to run cmass.infer.preprocess first.'
-                )
+            names = ['Omega_m', 'Omega_b', 'h', 'n_s', 'sigma_8']
+            filepath = join(exp_path, 'hodprior.csv')
+            if cfg.infer.subselect_cosmo is not None:
+                names = [names[i] for i in cfg.infer.subselect_cosmo]
+            if cfg.infer.include_hod and os.path.exists(filepath):
+                hodprior = np.genfromtxt(
+                    filepath, delimiter=',', dtype=object)
+                names += hodprior[:, 0].astype('str').tolist()
+            if cfg.infer.include_noise:
+                names += ['noise_radial', 'noise_transverse']
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f'Could not find test data for {name} with kmax={kmax}.'
+                'Make sure to run cmass.infer.preprocess first.'
+            )
         logging.info(f'Testing on {len(x_test)} examples')
 
         # load trained posterior

--- a/cmass/infer/validate_nle.py
+++ b/cmass/infer/validate_nle.py
@@ -22,7 +22,7 @@ import torch
 import matplotlib.pyplot as plt
 
 from .train_nle import load_nle
-from .tools import split_experiments
+from .tools import split_experiments, iter_kcuts, kcut_dirname
 from ..utils import timing_decorator, clean_up
 from ..nbody.tools import parse_nbody_config
 
@@ -130,64 +130,60 @@ def plot_emulations(model, x_test, theta_test, out_path, device='cpu',
 def run_experiment(exp, cfg, model_path):
     assert len(exp.summary) > 0, 'No summaries provided for inference'
     name = '+'.join(exp.summary)
-    kmin_list = exp.kmin if 'kmin' in exp else [0.]
-    kmax_list = exp.kmax if 'kmax' in exp else [0.4]
+    for kmin, kmax in iter_kcuts(exp):
+        log.info(
+            f'Running NLE validation for {name} '
+            f'with {kmin} <= k <= {kmax}')
+        exp_path = join(model_path, kcut_dirname(kmin, kmax))
 
-    for kmin in kmin_list:
-        for kmax in kmax_list:
-            log.info(
-                f'Running NLE validation for {name} '
-                f'with {kmin} <= k <= {kmax}')
-            exp_path = join(model_path, f'kmin-{kmin}_kmax-{kmax}')
+        # ── resolve test data path (OOD or in-distribution) ──────
+        if cfg.infer.testing.suite is None:
+            log.info(f'Loading test data from {exp_path}')
+            test_path = exp_path
+            out_path = exp_path
+        else:
+            test_path = join(
+                cfg.meta.wdir,
+                cfg.infer.testing.suite, cfg.infer.testing.sim,
+                'models', cfg.infer.tracer, name,
+                kcut_dirname(kmin, kmax))
+            log.info(f'Loading OOD test data from {test_path}')
+            out_path = join(
+                exp_path, 'testing',
+                f'{cfg.infer.testing.suite}_{cfg.infer.testing.sim}')
+            os.makedirs(out_path, exist_ok=True)
 
-            # ── resolve test data path (OOD or in-distribution) ──────
-            if cfg.infer.testing.suite is None:
-                log.info(f'Loading test data from {exp_path}')
-                test_path = exp_path
-                out_path = exp_path
-            else:
-                test_path = join(
-                    cfg.meta.wdir,
-                    cfg.infer.testing.suite, cfg.infer.testing.sim,
-                    'models', cfg.infer.tracer, name,
-                    f'kmin-{kmin}_kmax-{kmax}')
-                log.info(f'Loading OOD test data from {test_path}')
-                out_path = join(
-                    exp_path, 'testing',
-                    f'{cfg.infer.testing.suite}_{cfg.infer.testing.sim}')
-                os.makedirs(out_path, exist_ok=True)
+        try:
+            x_test = np.load(join(test_path, 'x_test.npy'))
+            theta_test = np.load(join(test_path, 'theta_test.npy'))
+        except FileNotFoundError:
+            log.error(
+                f'Missing test data in {test_path}. '
+                'Run cmass.infer.preprocess first.')
+            continue
 
-            try:
-                x_test = np.load(join(test_path, 'x_test.npy'))
-                theta_test = np.load(join(test_path, 'theta_test.npy'))
-            except FileNotFoundError:
-                log.error(
-                    f'Missing test data in {test_path}. '
-                    'Run cmass.infer.preprocess first.')
-                continue
+        log.info(f'Testing on {len(x_test)} examples')
 
-            log.info(f'Testing on {len(x_test)} examples')
+        # ── load trained NLE ─────────────────────────────────────
+        nle_path = join(exp_path, 'nle.pt')
+        if not os.path.exists(nle_path):
+            log.error(f'No NLE checkpoint at {nle_path}. '
+                      'Run cmass.infer.train_nle first.')
+            continue
 
-            # ── load trained NLE ─────────────────────────────────────
-            nle_path = join(exp_path, 'nle.pt')
-            if not os.path.exists(nle_path):
-                log.error(f'No NLE checkpoint at {nle_path}. '
-                          'Run cmass.infer.train_nle first.')
-                continue
+        model = load_nle(nle_path, device=cfg.infer.device)
+        log.info(f'Loaded NLE from {nle_path}')
 
-            model = load_nle(nle_path, device=cfg.infer.device)
-            log.info(f'Loaded NLE from {nle_path}')
+        segments = _load_segments(exp_path)
+        if segments is not None:
+            log.info(f'Colouring by segments: {[s[0] for s in segments]}')
 
-            segments = _load_segments(exp_path)
-            if segments is not None:
-                log.info(f'Colouring by segments: {[s[0] for s in segments]}')
-
-            # ── plot emulations ──────────────────────────────────────
-            plot_emulations(
-                model, x_test, theta_test,
-                join(out_path, 'nle_emulations.png'),
-                device=cfg.infer.device,
-                segments=segments)
+        # ── plot emulations ──────────────────────────────────────
+        plot_emulations(
+            model, x_test, theta_test,
+            join(out_path, 'nle_emulations.png'),
+            device=cfg.infer.device,
+            segments=segments)
 
 
 @timing_decorator


### PR DESCRIPTION
## What

Lets a single experiment apply **different kmax to different summaries** — e.g. P(k) out
to 0.6 but B(k) only to 0.2 — instead of one cut shared across all of them.

A `kmax` entry in an experiment may now be either:

- a **float**, applied to every summary (exactly as today), or
- a **mapping**, resolved per summary in decreasing specificity: exact name (`zPk4`) →
  family (`zPk`, `zQk`) → family with the triangle tag stripped (`zEqQk` → `zQk`) →
  `default`. A summary with no matching key and no `default` raises, so a typo fails
  loudly instead of silently falling back to 0.4.

`kmin` stays a scalar applied to all summaries.

```yaml
experiments:
  - summary: [zPk0, zPk2, zPk4, zQk0]
    kmin: [0.]
    kmax:
      - 0.4                    # uniform, as before
      - {zPk: 0.6, zQk: 0.2}   # P(k) to 0.6, Q(k) to 0.2
```

## How

The kmin/kmax double loop and the `kmin-{kmin}_kmax-{kmax}` directory string were
copy-pasted across six stages. They now share three helpers in `cmass/infer/tools.py`:

- `iter_kcuts(exp)` — yields the experiment's `(kmin, kmax)` cuts
- `resolve_kmax(kmax, summ)` — the float cut for one summary
- `kcut_dirname(kmin, kmax)` — the output directory name

`preprocess` is the only stage that consumes the cut *values*: it resolves kmax per
summary and passes the float to `preprocess_Pk` / `preprocess_Bk`, which already cut per
summary — so the loaders are unchanged. The other five stages (`optuna`, `train` ×2,
`train_nle`, `validate`, `validate_nle`) only use the cut to build `exp_path`.

Also replaces the `exp_path.split("/kmin")[0]` optuna study-name hack with
`basename(dirname(exp_path))`, which yields the same string by construction and doesn't
depend on the directory name starting with `kmin`.

## Backward compatibility

Every existing config yields a float `kmax`, so directory names stay byte-identical
(`kmin-0.0_kmax-0.4`) and splits and outputs are unchanged. The literal
`kmin-0.0_kmax-0.4` globs in `sufficiency.py`, `scripts/noise_calibration_all.py`,
`scripts/model_scaling_diagnostics.py` and `scripts/ood_noise_inference.py` keep working
— they simply won't see mixed-cut directories. Mixed cuts get an auto-derived,
deterministic name, e.g. `kmin-0.0_kmax-def=0.2__zPk=0.6__zPk4=0.3`.

## Notes

- **The SLURM scripts need no code change**, but their ranges do: `split_experiments`
  still flattens the kmin × kmax product, so `infer.exp_index` indexes the same way — but
  adding a mixed-cut entry lengthens that flat list, so the `--array` range in
  `jobs/slurm_infvalid.sh` and the `{0..15}` loop in `jobs/submit_slurm_train.sh` must be
  bumped to match the new experiment count.
- Fixes a latent bug in `validate.py`: the posterior-loading and validation block sat
  outside the `kmax` loop, so an experiment with several kmax values only ever validated
  the last one. It never bit us because `exp_index` hands each job a single cut.
  Collapsing to one loop fixes it.
- `cmass/conf/infer/mixk.yaml` is a worked example.
