### PR TITLE
Optimize fastpm postprocessing

### DIFF
--- a/cmass/diagnostics/summ.py
+++ b/cmass/diagnostics/summ.py
@@ -585,6 +585,10 @@ def summarize_lightcone_pypower(
 @hydra.main(version_base=None, config_path="../conf", config_name="config")
 @clean_up(hydra)
 def main(cfg: DictConfig) -> None:
+    # Filtering for necessary configs
+    cfg = OmegaConf.masked_copy(cfg, ['meta', 'nbody', 'sim', 'bias', 'survey',
+                                      'diag', 'noise', 'multisnapshot'])
+
     cfg = parse_nbody_config(cfg)
     cfg = parse_hod(cfg)
 

--- a/cmass/nbody/fastpm.py
+++ b/cmass/nbody/fastpm.py
@@ -233,6 +233,10 @@ def process_single_snapshot(cfg, workdir, a, delete_files=True):
         outfile.create_dataset('fvel', data=fvel)
     os.replace(outpath + '.tmp', outpath)
 
+    # Remove raw particle files when they've been converted
+    if delete_files:
+        shutil.rmtree(snapdir, ignore_errors=True)
+
 
 def _snapdir(workdir, cfg, a):
     return join(workdir, f'fastpm_B{cfg.nbody.B}_{a:.4f}')

--- a/jobs/slurm_3gpch_harvester.sh
+++ b/jobs/slurm_3gpch_harvester.sh
@@ -2,22 +2,20 @@
 #SBATCH --job-name=3gpch_harvest
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=32
-#SBATCH --mem=220G
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=80G
 #SBATCH --time=36:00:00
 #SBATCH --partition=cpu
 #SBATCH --account=bdne-delta-cpu
 #SBATCH --output=/work/hdd/bdne/maho3/jobout/%x_%A.out
 #SBATCH --error=/work/hdd/bdne/maho3/jobout/%x_%A.out
 
-# Harvester: converts snapshots left by 3gpch_prod producer jobs into
-# nbody.h5 (see scripts/harvest_fastpm.py). Scale horizontally by running
-# N sharded instances, e.g. for 4 harvesters:
-#   for k in 0 1 2 3; do
-#       sbatch --export=ALL,SHARD_K=$k,SHARD_N=4 \
-#           jobs/slurm_3gpch_harvester.sh
+# Harvester: converts snapshots left by 3gpch_prod producers into nbody.h5,
+# directly on shared scratch (no node-local copying; one serial converter
+# per job). Scale by running N sharded instances, e.g. for 10 harvesters:
+#   for k in $(seq 0 9); do
+#       sbatch --export=ALL,SHARD_K=$k,SHARD_N=10 jobs/slurm_3gpch_harvester.sh
 #   done
-# Defaults to a single unsharded harvester (SHARD_N=1).
 # Fully idempotent: safe to resubmit anytime to sweep up leftovers.
 
 SHARD_K=${SHARD_K:-0}
@@ -30,29 +28,25 @@ conda activate cmass
 cd /u/maho3/git/ltu-cmass
 
 scratchbase=/work/hdd/bdne/maho3/cmass_scratch/harvest
-localbase=/tmp/maho3/harvest_${SLURM_JOB_ID}
 outbase=/work/hdd/bdne/maho3/cmass-ili/mtnglike/fastpm/L3000-N384
 
-mkdir -p "$localbase"
-trap 'rm -rf "$localbase"' EXIT
-# NOTE: never trap-delete scratchbase — unconverted snapshots must survive
+# NOTE: never delete scratchbase here — unconverted snapshots must survive
 # for a rerun; the harvester deletes per-lhid data itself after conversion.
 
-(while true; do
-    echo "SCRATCH_USAGE $(date +%H:%M:%S) $(du -sBM $scratchbase 2>/dev/null | cut -f1) LOCAL $(du -sBM $localbase 2>/dev/null | cut -f1)"
-    sleep 60
-done) &
-monitor_pid=$!
+if [ "$SHARD_K" -eq 0 ]; then
+    (while true; do
+        echo "SCRATCH_USAGE $(date +%H:%M:%S) $(du -sBM $scratchbase 2>/dev/null | cut -f1)"
+        sleep 60
+    done) &
+    monitor_pid=$!
+fi
 
 PYTHONPATH=. python scripts/harvest_fastpm.py \
     --scratchbase "$scratchbase" \
-    --localbase "$localbase" \
     --outbase "$outbase" \
     --lhids $LHID_MIN $LHID_MAX \
     --shard $SHARD_K $SHARD_N \
-    --nmove 6 --nconvert 5 --local-cap-gb 500 \
-    --idle-timeout-min 120
+    --idle-timeout-min 3000
 
-kill $monitor_pid 2>/dev/null
-echo "Peak scratch (all shards combined):"
-grep -h SCRATCH_USAGE /work/hdd/bdne/maho3/jobout/3gpch_harvest_${SLURM_JOB_ID}.out | awk '{print $3}' | sort -n | tail -1
+[ -n "$monitor_pid" ] && kill $monitor_pid 2>/dev/null
+echo "shard $SHARD_K done"

--- a/scripts/harvest_fastpm.py
+++ b/scripts/harvest_fastpm.py
@@ -1,29 +1,34 @@
 """Harvester: converts FastPM snapshots from producer jobs into nbody.h5.
 
 Producers run cmass.nbody.fastpm with nbody.postprocess=False
-nbody.harvest=True and a fixed shared meta.scratchdir. This job scans their
-per-lhid workdirs, moves finished snapshots to node-local disk, converts them
-(same process_single_snapshot as the pipeline), concatenates each completed
-lhid into <outbase>/<lhid>/nbody.h5, and cleans up.
+nbody.harvest=True and a fixed shared meta.scratchdir. Each harvester job
+scans its shard of per-lhid workdirs and converts snapshots IN PLACE on the
+shared scratch (single serial converter, no copying to node-local disk):
+snapshot complete -> process_single_snapshot() reads it from scratch, writes
+nbody_{a}.h5 beside it, deletes the 47GB raw. When all snapshots of an lhid
+are converted and the producer is done, they are concatenated to
+<outbase>/<lhid>/nbody.h5 and the scratch dir is removed.
 
-Priority: move (drain quota'd shared scratch) while local disk < cap;
-convert otherwise. Producer job scripts touch .fastpm_done / .fastpm_failed
-in each lhid workdir.
+Scale by running N sharded instances (lhid % N == K); each lhid has exactly
+one owner, so no locking. Everything is idempotent and restart-safe: state
+lives entirely in the shared filesystem.
 
-Example:
+Producer job scripts touch .fastpm_done / .fastpm_failed in each lhid
+workdir; failed producers are skipped.
+
+Example (one shard of 10):
     PYTHONPATH=. python scripts/harvest_fastpm.py \
         --scratchbase /work/hdd/bdne/maho3/cmass_scratch/harvest \
-        --localbase /tmp/maho3/harvest \
         --outbase /work/hdd/bdne/maho3/cmass-ili/mtnglike/fastpm/L3000-N384 \
-        --lhids 3000 3014
+        --lhids 3000 3100 --shard 0 10
 """
 import argparse
 import logging
 import os
 import shutil
+import subprocess
 import time
 import h5py
-import multiprocessing as mp
 from os.path import join, isdir, exists
 
 from omegaconf import OmegaConf
@@ -45,23 +50,11 @@ def snapname(a):
     return f'fastpm_B{B}_{a:.4f}'
 
 
-def du_gb(path):
-    total = 0
-    for root, _, files in os.walk(path):
-        for f in files:
-            try:
-                total += os.path.getsize(join(root, f))
-            except OSError:
-                pass
-    return total / 1024**3
-
-
 class LhidState:
-    def __init__(self, lhid, scratchbase, localbase, outbase, cfg):
+    def __init__(self, lhid, scratchbase, outbase, cfg):
         self.lhid = lhid
         self.work = join(scratchbase, 'mtnglike', 'fastpm',
                          'L3000-N384', str(lhid))
-        self.local = join(localbase, str(lhid))
         self.outdir = join(outbase, str(lhid))
         self.cfg = cfg
         self.concat_done = exists(join(self.outdir, 'nbody.h5'))
@@ -73,16 +66,16 @@ class LhidState:
         return exists(join(self.work, '.fastpm_failed'))
 
     def done_h5(self, a):
-        # converted files are parked on shared scratch (survive restarts)
         return exists(join(self.work, f'nbody_{a:.4f}.h5'))
 
-    def movable(self):
-        """Snapshots complete in scratch: next snapshot exists or producer done."""
+    def convertible(self):
+        """Snapshots complete in scratch and not yet converted. Snapshot i is
+        complete once snapshot i+1's dir exists (FastPM writes sequentially)
+        or the producer has exited."""
         out = []
         for i, a in enumerate(ASAVE):
             src = join(self.work, snapname(a))
-            if (not isdir(src) or self.done_h5(a)
-                    or exists(join(self.local, f'.moved_{a:.4f}'))):
+            if not isdir(src) or self.done_h5(a):
                 continue
             nxt = i + 1 < len(ASAVE) and isdir(join(self.work,
                                                     snapname(ASAVE[i+1])))
@@ -90,50 +83,29 @@ class LhidState:
                 out.append(a)
         return out
 
-    def convertible(self):
-        return [a for a in ASAVE
-                if exists(join(self.local, f'.moved_{a:.4f}'))
-                and not self.done_h5(a)]
-
-    def converted(self):
-        return [a for a in ASAVE if self.done_h5(a)]
-
     def ready_to_concat(self):
         return (not self.concat_done and self.producer_done()
-                and len(self.converted()) == len(ASAVE))
+                and all(self.done_h5(a) for a in ASAVE))
 
 
-def do_move(args):
-    """Copy a snapshot to local disk. The scratch copy is kept until
-    conversion succeeds (do_convert deletes it), so a harvester crash or
-    restart never loses data — node-local /tmp is ephemeral."""
-    work, local, a = args
-    src, dst = join(work, snapname(a)), join(local, snapname(a))
-    marker = join(local, f'.moved_{a:.4f}')
-    os.makedirs(local, exist_ok=True)
-    if not isdir(dst):
-        shutil.copytree(src, dst + '.tmp', dirs_exist_ok=True)
-        os.rename(dst + '.tmp', dst)
-    open(marker, 'w').close()
-    logging.info(f'copied {os.path.basename(work)} a={a:.4f}')
-    return a
+def producers_alive(jobname):
+    """True if any producer job is still queued or running.
 
-
-def do_convert(args):
-    cfg, work, local, a = args
-    process_single_snapshot(cfg, local, a, delete_files=True)
-    # Park the small (~1GB) converted file on SHARED scratch before dropping
-    # the 47GB scratch original: after this, nothing irreplaceable lives on
-    # the ephemeral local disk, and quota is freed.
-    lf, wf = join(local, f'nbody_{a:.4f}.h5'), join(work, f'nbody_{a:.4f}.h5')
-    if not exists(wf):
-        shutil.copyfile(lf, wf + '.tmp')
-        os.replace(wf + '.tmp', wf)
-    src = join(work, snapname(a))
-    if isdir(src):
-        shutil.rmtree(src)
-    logging.info(f'converted lhid={cfg.nbody.lhid} a={a:.4f}')
-    return a
+    Queue waits here reach ~10h, so a harvester that idle-exits while
+    producers are merely PENDING leaves them writing 47GB snapshots with
+    nothing draining scratch -- this repeatedly filled the disk quota. On any
+    squeue failure we return True: 'unknown' must never be read as 'no
+    producers left'."""
+    try:
+        out = subprocess.run(
+            ['squeue', '-u', os.environ.get('USER', ''), '-h',
+             '-n', jobname, '-o', '%i'],
+            capture_output=True, text=True, timeout=60)
+        if out.returncode != 0:
+            return True
+        return bool(out.stdout.strip())
+    except Exception:
+        return True
 
 
 def concat(st):
@@ -146,7 +118,6 @@ def concat(st):
                 group.create_dataset('rho', data=f['rho'][:])
                 group.create_dataset('fvel', data=f['fvel'][:])
     os.replace(tmp, join(st.outdir, 'nbody.h5'))
-    shutil.rmtree(st.local, ignore_errors=True)
     shutil.rmtree(st.work, ignore_errors=True)
     st.concat_done = True
     logging.info(f'HARVESTED lhid={st.lhid} -> {st.outdir}/nbody.h5')
@@ -155,18 +126,16 @@ def concat(st):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--scratchbase', required=True)
-    ap.add_argument('--localbase', required=True)
     ap.add_argument('--outbase', required=True)
     ap.add_argument('--lhids', type=int, nargs=2, required=True,
-                    help='inclusive range, e.g. 3000 3014')
+                    help='inclusive range, e.g. 3000 3100')
     ap.add_argument('--shard', type=int, nargs=2, default=None,
                     metavar=('K', 'N'),
-                    help='process only lhids with lhid %% N == K, for '
-                         'running N independent harvesters in parallel')
-    ap.add_argument('--nmove', type=int, default=6)
-    ap.add_argument('--nconvert', type=int, default=5)
-    ap.add_argument('--local-cap-gb', type=float, default=500)
+                    help='process only lhids with lhid %% N == K')
     ap.add_argument('--idle-timeout-min', type=float, default=120)
+    ap.add_argument('--producer-name', default='3gpch_prod',
+                    help='SLURM job name of the producers; the harvester will '
+                         'not idle-exit while any are queued or running')
     ap.add_argument('--poll-sec', type=float, default=15)
     args = ap.parse_args()
 
@@ -176,69 +145,53 @@ def main():
         lhid_list = [l for l in lhid_list if l % n == k]
         logging.info(f'shard {k}/{n}: {len(lhid_list)} lhids')
 
-    os.makedirs(args.localbase, exist_ok=True)
     states = {}
     for lhid in lhid_list:
         cfg = OmegaConf.create(
             {'nbody': {'B': B, 'L': 3000, 'N': 384, 'lhid': lhid,
                        'asave': ASAVE,
                        'cosmo': [0.3089, 0.0486, 0.6774, 0.9667, 0.8159]}})
-        states[lhid] = LhidState(
-            lhid, args.scratchbase, args.localbase, args.outbase, cfg)
+        states[lhid] = LhidState(lhid, args.scratchbase, args.outbase, cfg)
 
-    mv_pool = mp.Pool(args.nmove)
-    cv_pool = mp.Pool(args.nconvert)
-    mv_busy, cv_busy = {}, {}   # (lhid, a) -> AsyncResult
     last_action = time.time()
-
     while True:
         pending = [s for s in states.values()
                    if not s.concat_done and not s.producer_failed()]
-        if not pending and not mv_busy and not cv_busy:
+        if not pending:
             logging.info('all lhids harvested')
             break
 
-        # reap finished tasks
-        for d in (mv_busy, cv_busy):
-            for key in [k for k, r in d.items() if r.ready()]:
-                d.pop(key).get()  # raise on worker error
-                last_action = time.time()
-
-        local_gb = du_gb(args.localbase)
+        worked = False
         for st in pending:
-            # concat when complete
-            if st.ready_to_concat() and not any(
-                    k[0] == st.lhid for k in list(mv_busy) + list(cv_busy)):
+            for a in st.convertible():
+                # one snapshot at a time, directly on shared scratch
+                process_single_snapshot(st.cfg, st.work, a, delete_files=True)
+                logging.info(f'converted lhid={st.lhid} a={a:.4f}')
+                worked = True
+            if st.ready_to_concat():
                 concat(st)
-                last_action = time.time()
-                continue
-            # moves first while local disk has room
-            if local_gb < args.local_cap_gb and len(mv_busy) < args.nmove:
-                for a in st.movable():
-                    key = (st.lhid, a)
-                    if key not in mv_busy and len(mv_busy) < args.nmove:
-                        mv_busy[key] = mv_pool.apply_async(
-                            do_move, ((st.work, st.local, a),))
-            # conversions
-            if len(cv_busy) < args.nconvert:
-                for a in st.convertible():
-                    key = (st.lhid, a)
-                    if (key not in cv_busy and key not in mv_busy
-                            and len(cv_busy) < args.nconvert):
-                        cv_busy[key] = cv_pool.apply_async(
-                            do_convert, ((st.cfg, st.work, st.local, a),))
+                worked = True
 
         failed = [s.lhid for s in states.values() if s.producer_failed()]
         if failed:
             logging.warning(f'skipping failed producers: {failed}')
 
-        if time.time() - last_action > args.idle_timeout_min * 60:
-            logging.warning('idle timeout; exiting (rerun to resume)')
-            break
-        time.sleep(args.poll_sec)
+        if worked:
+            last_action = time.time()
+        elif time.time() - last_action > args.idle_timeout_min * 60:
+            if producers_alive(args.producer_name):
+                logging.info(
+                    f'idle {args.idle_timeout_min:.0f}min but producers still '
+                    'queued/running; staying alive')
+                last_action = time.time()
+                time.sleep(args.poll_sec)
+            else:
+                logging.warning('idle timeout, no live producers; exiting '
+                                '(rerun to resume)')
+                break
+        else:
+            time.sleep(args.poll_sec)
 
-    mv_pool.close()
-    cv_pool.close()
     done = sorted(l for l, s in states.items() if s.concat_done)
     logging.info(f'harvested lhids: {done}')
 


### PR DESCRIPTION
Makes small changes to summ.py to reduce verbosity and fastpm.py to cleanup particle snapshots once they've been reprocessed.

Also, simplifies the fastpm producer/harvester loop:

> Removes the node-local staging step from the FastPM harvester and fixes a disk-quota incident caused by idle-timeout racing with queued producers.
> 
> Previously, each harvested snapshot was copied from shared scratch to node-local /tmp, converted there, copied back, then cleaned up — coordinated by separate move/convert worker pools (--nmove/--nconvert/--local-cap-gb). This added complexity and a redundant copy for no real benefit, since node-local disk wasn't actually a bottleneck here.
> 
> The harvester now runs process_single_snapshot() directly on shared scratch, one snapshot at a time, serially. This is simpler, avoids the extra copy, and lets us shrink the per-job resource request (cpus-per-task 32→8, mem 220G→80G).
> 
> Separately, this fixes a real incident: the harvester was idle-exiting after its timeout even when producer jobs were still queued (not yet running), because the timeout only checked for local activity, not producer state. With nothing draining scratch during a long queue wait, snapshots piled up and repeatedly filled the disk quota. producers_alive() now checks squeue for the producer job name before allowing an idle-exit, and conservatively assumes producers are alive if the squeue check itself fails. --idle-timeout-min is bumped from 120 to 3000 to give this room to work given typical queue wait times (~10h).
> 
> Job script also now only runs the scratch-usage monitor loop on shard 0, to avoid duplicate logging when running multiple sharded harvesters in parallel.