### PR TITLE
Survey randoms: skip fiber collisions, native n(z) targets

### DIFF
--- a/cmass/conf/survey/default.yaml
+++ b/cmass/conf/survey/default.yaml
@@ -13,8 +13,19 @@ z_range: [0.4, 0.7]
 boss_dir: "${meta.wdir}/obs/"  # path to observational masks
 fix_nz: False
 
+# Multiplier on the observed n(z) target used by fix_nz. 1 reproduces the
+# observed number counts; >1 is for randoms, which want the same n(z) shape
+# at higher density. May be a scalar or a list with one entry per z-bin of
+# the target file. Ignored unless fix_nz is True.
+nz_factor: 1
+
 # For randoms creation only (will not load any correct data!)
 randoms: False
+
+# Comoving number density of the uniform cube fed to the randoms lightcone,
+# in (h/Mpc)^3, before any n(z) downsampling. Must be high enough that every
+# z-bin can saturate nz_factor x the observed n(z).
+randoms_nbar: 3.0e-3
 
 # For turning off all masking (only for testing footprint coverage!)
 nomask: False

--- a/cmass/diagnostics/calculations.py
+++ b/cmass/diagnostics/calculations.py
@@ -305,11 +305,9 @@ def calcBk_polybin_survey(field, mask, L, boxcenter, threads=16,
     `survey.randoms=true`, which pushes a *uniform random cube* through the
     lightcone (hodlightcone.stitch_lightcone), so they carried only the
     angular mask and the z-range cut and were uniform in comoving volume --
-    dN/dz tracking dV/dz to ~3%. Randoms built with `survey.fix_nz=true`
-    (plus `survey.nz_factor`) instead follow the observed CMASS n(z) and
-    largely remove this term.
+    dN/dz tracking dV/dz to ~3%.
 
-    Measured consequence with the legacy uniform randoms (ngc real_data,
+    Measured consequence with those legacy uniform randoms (ngc real_data,
     nmesh=240): polybin/pypower = 0.7792, flat in k to 4 decimals and
     identical for P_0 and P_2. The normalization is a scalar, so it can only
     ever be an amplitude convention, never a k- or multipole-dependent
@@ -319,10 +317,33 @@ def calcBk_polybin_survey(field, mask, L, boxcenter, threads=16,
     the n(z) mismatch (a radial catalog-only estimate of the cross/auto
     ratio gives 0.758).
 
+    The randoms have since been rebuilt with `survey.fix_nz=true` plus
+    `survey.nz_factor=10`, so they follow the observed CMASS n(z) at 10x
+    density, and this term is now small. Re-measured on the same catalog by
+    scripts/check_lightcone_norm_ratio.py:
+
+        nmesh   new randoms   uniform-in-dV control
+        120     1.0332        0.8339
+        240     0.9895        0.7378
+
+    i.e. a 26% mismatch at nmesh=240 becomes 1.0%. The control is built by
+    subsampling the current randoms back to a dV/dz shape, which leaves only
+    1.54M of them against the real randoms' 5.79M; the extra Poisson variance
+    in <mask^2> biases it low, which is why it reads 0.7378 rather than the
+    0.7792 measured on the actual legacy randoms. Read the improvement as
+    0.78 -> 0.99.
+
+    The residual ~1% is the C++ downsampler enforcing n(z) only in the 10
+    coarse dz=0.03 bins of the target file; within a bin the randoms still
+    carry the dV/dz shape. Finer target bins would reduce it further.
+
     Note this factor is *not* identical across lhids: it depends on each
-    mock's n(z) through alpha and the FKP weights. It also grows as the mesh
-    gets finer, so do not compare absolute amplitudes across different
-    nmesh. See the module docstring of check_lightcone_bk_maskshot.py.
+    mock's n(z) through alpha and the FKP weights. It also moves further from
+    1 as the mesh gets finer, so do not compare absolute amplitudes across
+    different nmesh -- note that all of that mesh dependence is in polybin's
+    <mask^2>, since pypower's wnorm is computed on its own fixed 10 Mpc/h
+    mesh and is identical at both resolutions above. See the module docstring
+    of check_lightcone_bk_maskshot.py.
 
     Both arrays must already be in PolyBin's real-space layout, i.e.
     `np.fft.ifftshift`-ed out of pypower's corner-first ordering; see

--- a/cmass/lightcone/lightcone.cpp
+++ b/cmass/lightcone/lightcone.cpp
@@ -6,6 +6,7 @@
 #include <climits>
 
 #include <vector>
+#include <string>
 #include <functional>
 #include <map>
 #include <utility>
@@ -200,6 +201,13 @@ struct Lightcone
     const unsigned augment;
     const unsigned long seed;
     const bool is_north;
+    const bool skip_fibcoll;
+    // name of the n(z) target cap (e.g. "North", "South", "MTNG").
+    // empty -> fall back to is_north
+    const std::string nz_cap;
+    // multiplies the target n(z) bins. empty -> 1, size 1 -> scalar,
+    // otherwise one entry per bin
+    const std::vector<double> nz_factor;
     const std::vector<double> snap_times;
     size_t Nsnaps;
     std::vector<double> snap_redshifts, snap_chis, redshift_bounds, chi_bounds;
@@ -229,9 +237,14 @@ struct Lightcone
                double BoxSize_=3e3, int remap_case_=0,
                bool verbose_=false, unsigned augment_=0,
                double sigmaradial_=0.0, double sigmatransverse_=0.0,
-               unsigned long seed_=137UL, bool is_north_=true) :
+               unsigned long seed_=137UL, bool is_north_=true,
+               bool skip_fibcoll_=false,
+               const std::string &nz_cap_=std::string(),
+               const std::vector<double> &nz_factor_=std::vector<double>()) :
         mask{mask_},
         is_north{is_north_},
+        skip_fibcoll{skip_fibcoll_},
+        nz_cap{nz_cap_}, nz_factor{nz_factor_},
         // hod_fct{hod_fct_},
         Omega_m{Omega_m_}, zmin{zmin_}, zmax{zmax_}, zmid{zmid_},
         snap_times{snap_times_}, Nsnaps{snap_times_.size()},
@@ -340,21 +353,27 @@ struct Lightcone
         if (snap_indices_done.size() != Nsnaps)
             throw std::runtime_error("not all snapshots have been added");
 
-        if (do_downsample)
+        // randoms should not be thinned by fiber collisions -- they trace the
+        // selection function, not the instrument
+        if (!skip_fibcoll)
         {
-            // get an idea of the fiber collision rate in our sample,
-            // so the subsequent downsampling is to the correct level.
-            // This is justified as all this stuff is not super expensive.
-            double fibcoll_rate = fibcoll</*only_measure=*/true>();
+            if (do_downsample)
+            {
+                // get an idea of the fiber collision rate in our sample,
+                // so the subsequent downsampling is to the correct level.
+                // This is justified as all this stuff is not super expensive.
+                double fibcoll_rate = fibcoll</*only_measure=*/true>();
 
-            // first downsampling before fiber collisions are applied
-            if (verbose) std::printf("downsample\n");
-            downsample(fibcoll_rate+Numbers::fibcoll_rate_correction);
+                // first downsampling before fiber collisions are applied
+                if (verbose) std::printf("downsample\n");
+                downsample(fibcoll_rate+Numbers::fibcoll_rate_correction);
+            }
+
+            // apply fiber collisions
+            if (verbose) std::printf("fibcoll\n");
+            fibcoll</*only_measure=*/false>();
         }
-
-        // apply fiber collisions
-        if (verbose) std::printf("fibcoll\n");
-        fibcoll</*only_measure=*/false>(); 
+        else if (verbose) std::printf("skipping fibcoll\n");
 
         // now downsample to our final density
         if (do_downsample)
@@ -411,14 +430,19 @@ PYBIND11_MODULE(lc, m)
                        bool, unsigned,
                        double, double,
                        unsigned long,
-                       bool>(),
+                       bool, bool,
+                       const std::string &,
+                       const std::vector<double> &>(),
             "mask"_a, "Omega_m"_a, "zmin"_a, "zmax"_a, "zmid"_a, "snap_times"_a,
             pyb::kw_only(),
             "boss_dir"_a=nullptr,
             "BoxSize"_a=3e3, "remap_case"_a=0,
             "verbose"_a=false, "augment"_a=0,
             "sigmaradial"_a=0.0, "sigmatransverse"_a=0.0,
-            "seed"_a=137UL, "is_north"_a=true
+            "seed"_a=137UL, "is_north"_a=true,
+            "skip_fibcoll"_a=false,
+            "nz_cap"_a=std::string(),
+            "nz_factor"_a=std::vector<double>()
         )
         .def("set_hod", &Lightcone::set_hod, "hod_fct"_a)
         .def("add_snap", &Lightcone::add_snap, "snap_idx"_a, "xhlo"_a, "vhlo"_a)
@@ -434,16 +458,27 @@ void Lightcone::read_boss_nz (void)
     // text file, each line number of objects in a redshift bin
     // we assume bins are equally spaced in redshift between zmin and zmax,
     // number of bins is inferred from the file
-    if (is_north)
-        std::snprintf(fname, 512, "%s/nz_DR12v5_CMASS_North_zmin%.4f_zmax%.4f.dat",
-                      boss_dir, zmin, zmax);
-    else
-        std::snprintf(fname, 512, "%s/nz_DR12v5_CMASS_South_zmin%.4f_zmax%.4f.dat",
-                      boss_dir, zmin, zmax);
+    const std::string cap = nz_cap.empty() ? (is_north ? "North" : "South")
+                                           : nz_cap;
+    std::snprintf(fname, 512, "%s/nz_DR12v5_CMASS_%s_zmin%.4f_zmax%.4f.dat",
+                  boss_dir, cap.c_str(), zmin, zmax);
     auto fp = std::fopen(fname, "r");
+    if (!fp)
+        throw std::runtime_error(std::string("could not open n(z) target ")+fname);
     char line[64];
     while (std::fgets(line, 64, fp))
         nz.push_back(std::atof(line));
+    std::fclose(fp);
+
+    if (nz.empty())
+        throw std::runtime_error(std::string("empty n(z) target ")+fname);
+
+    // scale the target, either by a scalar or per-bin
+    if (nz_factor.size() > 1 && nz_factor.size() != nz.size())
+        throw std::runtime_error("nz_factor length does not match number of n(z) bins");
+    if (!nz_factor.empty())
+        for (size_t ii=0; ii<nz.size(); ++ii)
+            nz[ii] *= (nz_factor.size()==1) ? nz_factor[0] : nz_factor[ii];
 
     boss_z_hist = gsl_histogram_alloc(nz.size());
     gsl_histogram_set_ranges_uniform(boss_z_hist, zmin, zmax);

--- a/cmass/survey/hodlightcone.py
+++ b/cmass/survey/hodlightcone.py
@@ -26,7 +26,9 @@ NOTE:
     - This only works for snapshot mode, wherein lightcone evolution is
     mimicked by stitching snapshots together. For the non-snapshot mode
     alternative, use 'ngc_selection.py'.
-    - The fiber collisions are applied in-sync with resampling.
+    - The fiber collisions are applied in-sync with resampling. They are
+    skipped entirely when survey.randoms=True, since randoms should trace
+    the selection function rather than the instrument.
 """
 
 import os
@@ -55,15 +57,20 @@ def split_galsnap_galidx(gid):
 
 
 def stitch_lightcone(lightcone, source_path, snap_times, BoxSize, Ngrid,
-                     noise_uniform, use_randoms=False):
+                     noise_uniform, use_randoms=False, randoms_nbar=3.0e-3):
     # Load snapshots
     for snap_idx, a in enumerate(snap_times):
         logging.info(f'Loading snapshot at a={a:.6f}...')
         if not use_randoms:
             hpos, hvel, _, _ = load_snapshot(source_path, a)
         else:
-            nbar_randoms = 10*3e-4  # 10x number density of CMASS
-            Nrandoms = int(nbar_randoms * BoxSize**3)
+            # Uniform cube, later downsampled to the target n(z) if fix_nz.
+            # randoms_nbar must exceed the peak target density in every
+            # z-bin or the downsampling cannot saturate; see the
+            # survey.randoms_nbar comment in conf/survey/default.yaml.
+            Nrandoms = int(randoms_nbar * BoxSize**3)
+            logging.info(f'Drawing {Nrandoms} uniform randoms '
+                         f'(nbar={randoms_nbar:.3e} (h/Mpc)^3)')
             hpos = np.random.rand(Nrandoms, 3) * BoxSize
             hvel = np.zeros_like(hpos)
 
@@ -89,20 +96,41 @@ def stitch_lightcone(lightcone, source_path, snap_times, BoxSize, Ngrid,
     return ra, dec, z, galsnap, galidx
 
 
-def check_saturation(z, nz_dir, zmin, zmax, geometry):
-    if geometry == 'ngc':
-        cap = 'North'
-    elif geometry == 'sgc':
-        cap = 'South'
-    elif geometry == 'mtng':
-        cap = 'MTNG'
-    else:
-        return False  # SIMBIG hasn't been calculated yet
-        raise ValueError(geometry)
+def _nz_cap(geometry):
+    """Cap name in the n(z) target filename, or None if we have no target."""
+    return {'ngc': 'North', 'sgc': 'South', 'mtng': 'MTNG'}.get(geometry)
 
-    filepath = join(
-        nz_dir, f'nz_DR12v5_CMASS_{cap}_zmin{zmin:.4f}_zmax{zmax:.4f}.dat')
-    nzobs = np.loadtxt(filepath, usecols=(0,))
+
+def load_nz_target(nz_dir, geometry, zmin, zmax, factor=1):
+    """Load the n(z) target counts the C++ lightcone downsamples to.
+
+    `factor` scales the observed counts. fix_nz alone downsamples to exactly
+    the observed n(z); randoms want that same *shape* at higher density, so
+    factor=10 gives 10x the observed n(z). It may be a scalar or a per-bin
+    vector -- mtng needs the latter, because its angular cut is applied
+    *after* the C++ downsampling (see main), so the target has to be
+    pre-inflated by 1/survival to land on the requested factor.
+    """
+    cap = _nz_cap(geometry)
+    if cap is None:
+        raise ValueError(f'No n(z) target available for geometry {geometry}')
+
+    src = join(nz_dir,
+               f'nz_DR12v5_CMASS_{cap}_zmin{zmin:.4f}_zmax{zmax:.4f}.dat')
+    counts = np.loadtxt(src, usecols=(0,))
+    factor = np.asarray(factor, dtype=float)
+    if factor.ndim and len(factor) != len(counts):
+        raise ValueError(
+            f'nz_factor has {len(factor)} entries but the {cap} target has '
+            f'{len(counts)} bins')
+    return counts * factor
+
+
+def check_saturation(z, nz_dir, zmin, zmax, geometry, factor=1):
+    if _nz_cap(geometry) is None:
+        return False  # SIMBIG hasn't been calculated yet
+
+    nzobs = load_nz_target(nz_dir, geometry, zmin, zmax, factor)
     zbins = np.linspace(zmin, zmax, len(nzobs)+1)
 
     # Check if n(z) is saturated (within 1-sigma of observed n(z))
@@ -202,6 +230,20 @@ def main(cfg: DictConfig) -> None:
         maskobs = None
         zmin, zmax = 0.0, 1.1  # midpoint is the same
 
+    # If fix_nz, resolve the n(z) target. The C++ reads it from nz_dir, keyed
+    # by cap name, and scales each bin by nz_factor (scalar or per-bin).
+    # nz_factor>1 gives the observed shape at higher density, for randoms.
+    nz_factor = getattr(cfg.survey, 'nz_factor', 1)
+    if OmegaConf.is_config(nz_factor):
+        nz_factor = OmegaConf.to_object(nz_factor)
+    nz_factor = np.atleast_1d(np.asarray(nz_factor, dtype=float)).tolist()
+    if cfg.survey.fix_nz:
+        # fails loudly here if the geometry has no target / wrong bin count
+        target = load_nz_target(nz_dir, geometry, zmin, zmax,
+                                np.squeeze(nz_factor))
+        logging.info(f'n(z) target for {geometry}: {target.sum():.0f} objects '
+                     f'over {len(target)} bins')
+
     # Setup lightcone
     snap_times = sorted(cfg.nbody.asave)[::-1]  # decreasing order
     snap_times = [a for a in snap_times if (zmin < (1/a - 1) < zmax)]
@@ -220,7 +262,12 @@ def main(cfg: DictConfig) -> None:
         sigmaradial=cfg.noise.radial,
         sigmatransverse=cfg.noise.transverse,
         seed=42,
-        is_north=geometry == 'ngc'
+        is_north=geometry == 'ngc',
+        # randoms trace the selection function, so they must not be thinned
+        # by fiber collisions (also by far the most expensive step)
+        skip_fibcoll=bool(cfg.survey.randoms),
+        nz_cap=_nz_cap(geometry) or '',
+        nz_factor=nz_factor
     )
 
     # Setup HOD model function
@@ -234,7 +281,8 @@ def main(cfg: DictConfig) -> None:
     ra, dec, z, galsnap, galidx = stitch_lightcone(
         lightcone, source_path, snap_times,
         cfg.nbody.L, cfg.nbody.N, cfg.bias.hod.noise_uniform,
-        use_randoms=cfg.survey.randoms)
+        use_randoms=cfg.survey.randoms,
+        randoms_nbar=float(getattr(cfg.survey, 'randoms_nbar', 3.0e-3)))
 
     # If SIMBIG, apply selection
     if geometry == 'simbig' and not cfg.survey.nomask:
@@ -253,7 +301,9 @@ def main(cfg: DictConfig) -> None:
     if cfg.survey.nomask:
         saturated = False
     else:
-        saturated = check_saturation(z, nz_dir, zmin, zmax, geometry)
+        saturated = check_saturation(
+            z, nz_dir, zmin, zmax, geometry,
+            np.squeeze(nz_factor) if cfg.survey.fix_nz else 1)
 
     # Save
     if geometry == 'ngc':

--- a/jobs/slurm_randoms_nz.sh
+++ b/jobs/slurm_randoms_nz.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+#SBATCH --job-name=randoms_nz   # Job name
+#SBATCH --array=0-2             # 0=ngc, 1=sgc, 2=mtng
+#SBATCH --nodes=1               # Number of nodes
+#SBATCH --ntasks=32             # Number of tasks
+#SBATCH --mem=180GB             # ngc draws 1.6e8 uniform points x 3 snapshots
+#SBATCH --time=06:00:00         # Time limit
+#SBATCH --partition=cpu         # Partition name
+#SBATCH --account=bdne-delta-cpu  # Account name
+#SBATCH --output=/work/hdd/bdne/maho3/jobout/%x_%A_%a.out
+#SBATCH --error=/work/hdd/bdne/maho3/jobout/%x_%A_%a.out
+
+# Regenerate the shared survey randoms so they trace 10x the observed CMASS
+# n(z) instead of being uniform in comoving volume.
+#
+# The previous randoms were built with survey.fix_nz=False, which feeds a
+# uniform random cube through the lightcone: they carried only the angular
+# mask and the z-range cut, so their dN/dz tracked dV/dz to ~3% rather than
+# the observed n(z). fix_nz=True downsamples to the target n(z) in
+# cmass/lightcone/nz_DR12v5_CMASS_*.dat, and survey.nz_factor scales that
+# target so we keep the observed *shape* at 10x the density.
+#
+# survey.randoms_nbar must exceed the peak target density in every z-bin or
+# the downsampling cannot saturate. Required minima measured against the old
+# randoms: ngc 1.45x, sgc 1.38x, mtng 2.70x the old 3e-3, so we use 6e-3 for
+# ngc/sgc and 1.2e-2 for mtng (doubled to 2.4e-2 below, since mtng's target is
+# pre-inflated for the post-finalize octant cut).
+#
+# survey.randoms=True now also sets skip_fibcoll in the C++ lightcone, so the
+# randoms skip the (expensive) fiber-collision pass and the pre-inflated
+# downsampling that compensates for it. Mocks are unaffected.
+#
+# NOTE: this OVERWRITES the randoms in place. Every existing lightcone diag
+# summary was computed against the old randoms and becomes inconsistent.
+
+source ~/.bashrc
+conda activate cmass
+
+module load gsl
+export CPATH=$GSL_ROOT_DIR/include:${CPATH:-}
+export LIBRARY_PATH=$GSL_ROOT_DIR/lib:${LIBRARY_PATH:-}
+export LD_LIBRARY_PATH=/u/maho3/anaconda3/envs/cmass/lib:$GSL_ROOT_DIR/lib:${LD_LIBRARY_PATH:-}
+
+# Fail the array task if the run fails, rather than falling through to the
+# trailing echo and reporting COMPLETED. Set after sourcing bashrc/module,
+# which are not -e clean.
+set -eo pipefail
+
+cd /u/maho3/git/ltu-cmass
+
+# export TQDM_DISABLE=0
+
+case $SLURM_ARRAY_TASK_ID in
+    0)  # ngc -> quijote3gpch/randoms/L3000-N384/0/ngc_lightcone
+        cap=ngc
+        nbody=quijote3gpch
+        # multisnapshot is pointless for randoms: stitch_lightcone draws an
+        # independent uniform cube per snapshot with zero velocities, so the
+        # snapshots are statistically identical and there is nothing to
+        # interpolate. This halves the draw, 2 cubes -> 1 (15.6 -> 7.8 GB).
+        #
+        # nbody.zf=0.5 is required, not cosmetic: multisnapshot=False sets
+        # asave=[1/(1+zf)], and quijote3gpch has zf=0.3, which the
+        # zmin<z<zmax snapshot filter then discards -- leaving zero
+        # snapshots and an empty lightcone. abacus (sgc/mtng) already has
+        # zf=0.5, which is why they run single-snapshot as-is.
+        multisnapshot=False
+        nbar=6.0e-3
+        nz_factor=10
+        extras="nbody.zf=0.5"
+        ;;
+    1)  # sgc -> abacus/randoms/L2000-N256/0/sgc_lightcone
+        cap=sgc
+        nbody=abacus
+        multisnapshot=False
+        nbar=6.0e-3
+        nz_factor=10
+        extras="meta.cosmofile=./params/abacus_cosmologies.txt"
+        ;;
+    2)  # mtng -> abacus/randoms/L2000-N256/0/mtng_lightcone
+        # mtng's angular cut (ra,dec in [0,90)) is applied in
+        # hodlightcone.main AFTER lightcone.finalize(), i.e. after the C++
+        # downsamples to the target, so ~30% of the downsampled sample is
+        # discarded and a flat factor lands short. These per-bin factors
+        # pre-inflate the target by 1/survival; regenerate them with
+        #     python scripts/mtng_nz_survival.py --achieved 10 --want 10
+        # Pre-cut target is 11.3M (vs 7.9M post-cut), so nbar is raised 2x.
+        cap=mtng
+        nbody=abacus
+        multisnapshot=False
+        nbar=2.4e-2
+        nz_factor="[15.604,15.133,14.747,14.433,14.171,13.938,13.734,13.594,13.424,13.291]"
+        extras="meta.cosmofile=./params/abacus_cosmologies.txt"
+        ;;
+    *)
+        echo "Unknown array index $SLURM_ARRAY_TASK_ID"; exit 1
+        ;;
+esac
+
+echo "Generating $cap randoms: nbody=$nbody nbar=$nbar factor=$nz_factor"
+
+# sim=randoms and lhid=0 put the output exactly on top of the existing
+# randoms, which is what cmass.diagnostics.pypower.get_randoms_file reads.
+python -m cmass.survey.hodlightcone \
+    nbody=$nbody sim=randoms nbody.lhid=0 \
+    multisnapshot=$multisnapshot \
+    survey.geometry=$cap \
+    survey.randoms=True \
+    survey.fix_nz=True \
+    "survey.nz_factor=$nz_factor" \
+    survey.randoms_nbar=$nbar \
+    survey.aug_seed=0 \
+    bias.hod.seed=0 \
+    bias.hod.noise_uniform=False \
+    $extras \
+    hydra/job_logging=disabled
+
+echo "Done $cap"


### PR DESCRIPTION
Regenerates the shared ngc/sgc/mtng survey randoms so they trace the observed CMASS n(z) at 10x density, and removes two workarounds in the lightcone code that made that awkward and slow.

## Motivation

The randoms used by `cmass.diagnostics.pypower` were built with `survey.fix_nz=False`: a uniform random cube pushed through the lightcone, carrying only the angular mask and the z-range cut. Their dN/dz therefore tracked dV/dz, not the observed n(z) -- off by 0.5-3.7x across 0.4 < z < 0.7 for ngc/sgc.

**This is nonstandard.** Previous approaches simply 'shuffled' their angular positions around, keeping an n(z) which matched the observations (without clustering). See Section 2.3 of https://arxiv.org/pdf/1401.1768 .

Fixing that with the existing code hit two problems in `cmass/lightcone/lightcone.cpp`:

1. `_finalize()` ran `fibcoll<false>()` unconditionally, so randoms were thinned by fiber collisions -- wrong (an instrumental effect should thin the data, not the selection-function trace) and by far the most expensive step in the run.
2. `read_boss_nz()` picked its target file from `is_north` alone, with no MTNG branch and no way to scale the target. `hodlightcone.py` worked around it by pre-writing edited `.dat` files into `$wdir/scratch/nz_targets/` under two filenames.

## Changes

`cmass/lightcone/lightcone.cpp` -- three new constructor arguments, all exposed to pybind11 and all defaulting to the old behavior:

- `skip_fibcoll` skips the fibcoll passes and the pre-inflated downsampling that compensates for them. The final `downsample(0.0)` still runs.
- `nz_cap` names the n(z) target file's cap; empty falls back to `is_north`.
- `nz_factor` scales the target bins as they are read (scalar or per-bin, length-checked).
- `read_boss_nz()` now raises on a missing/empty target instead of dereferencing a null `FILE*`.

`cmass/survey/hodlightcone.py` -- passes `skip_fibcoll=cfg.survey.randoms`, `nz_cap=`, `nz_factor=` straight through. `prepare_nz_target()` and the duplicate-file workaround are deleted; `check_saturation()` applies the factor itself. `stitch_lightcone` takes `randoms_nbar` instead of a hardcoded `10*3e-4`.

New config keys `survey.nz_factor` and `survey.randoms_nbar`. New: `jobs/slurm_randoms_nz.sh` (regenerates all three caps), `scripts/plot_randoms_nz.py`, `scripts/mtng_nz_survival.py` (mtng's per-bin factor), `scripts/check_lightcone_norm_ratio.py` + `jobs/slurm_norm_ratio.sh`. Docstring update in `cmass/diagnostics/calculations.py`.

## Results

All three caps regenerated in place, `python scripts/plot_randoms_nz.py --caps ngc sgc mtng`:

<img width="1650" height="1530" alt="image" src="https://github.com/user-attachments/assets/fcf0f172-b7df-451e-99ca-f40a9e701a46" />

| cap | N | max abs(randoms/target - 1) | runtime |
|---|---|---|---|
| ngc | 5,788,631 | 0.15% | 2:05 |
| sgc | 2,131,623 | 0.61% | 0:59 |
| mtng | 7,962,861 | 2.40% (excess at low z) | 3:11 |

Runtimes are minutes rather than the hours that motivated this, which is `skip_fibcoll` working. mtng's residual is an excess, not a shortfall, so it is harmless; `scripts/mtng_nz_survival.py` would close it.

**The pypower/PolyBin3D normalization gap closes.** The two estimators share a numerator but divide by different normalizations (pypower's `wnorm` is the data x randoms *cross* product, PolyBin's `<mask^2>` the randoms *auto* product), so the ratio is a scalar that equals 1 only if `alpha*n_r` traces `n_d`. Measured by `scripts/check_lightcone_norm_ratio.py` on ngc real_data, against a control built by subsampling the new randoms back to a dV/dz shape:

| nmesh | new randoms | uniform-in-dV control |
|---|---|---|
| 120 | 1.0332 | 0.8339 |
| 240 | **0.9895** | 0.7378 |

A 26% mismatch at nmesh=240 becomes 1.0%. The control reads low because subsampling leaves only 1.54M objects (extra Poisson variance in `<mask^2>`), so against the 0.7792 originally measured on the real legacy randoms the honest before/after is **0.78 -> 0.99**. Only same-nmesh numbers are comparable; all the nmesh dependence is in PolyBin's `<mask^2>`, since pypower's `wnorm` came out identical (11.5192) at both. The residual ~1% is the downsampler enforcing n(z) only in the 10 coarse dz=0.03 target bins.

## Notes for the reviewer

- **This overwrites the randoms in place**, so every lightcone summary built against the old ones is stale -- both in selection function and by the ~26% amplitude convention above. Nothing has been recomputed yet: `mtnglike/fastpm_charm7/**/diag/mtng_lightcone/*.h5` (41 files), `real_data/cmass_ngc/**/diag/ngc_lightcone/*.h5` (1 file).
- `cmass/lightcone/lc*.so` must be rebuilt (`cd cmass/lightcone && make`, needs GSL + pybind11).
- mtng's `check_saturation` always returns `False`: its angular cut is applied after `finalize()`, so a post-cut sample is compared against a pre-inflated target. Pre-existing; `plot_randoms_nz.py` is the real check.
- The branch carries unrelated history. This work is only: `cmass/lightcone/lightcone.cpp`, `cmass/survey/hodlightcone.py`, `cmass/diagnostics/calculations.py`, `cmass/conf/survey/default.yaml`, `jobs/slurm_randoms_nz.sh`, `jobs/slurm_norm_ratio.sh`, `scripts/{plot_randoms_nz,mtng_nz_survival,check_lightcone_norm_ratio}.py`.
